### PR TITLE
Fix for prompt leaking into audio when text prompt was not included

### DIFF
--- a/src/s2_prompt.cpp
+++ b/src/s2_prompt.cpp
@@ -76,7 +76,7 @@ PromptTensor build_prompt(
         // sys_pre is empty, everything goes into sys_post
         app(sys_post, tokenizer.encode("<|im_start|>system"));
         app(sys_post, NEWLINE);
-        app(sys_post, tokenizer.encode("You are a helpful assistant."));
+        app(sys_post, tokenizer.encode("convert the provided text to speech."));
         app(sys_post, { im_end_id });
         app(sys_post, NEWLINE);
         app(sys_post, tokenizer.encode("<|im_start|>user"));


### PR DESCRIPTION
When I did not provide a text prompt the audio would sometimes contain "You are a helpful assistant." This new prompt prevented that in my testing.