### PR TITLE
Fix Model Prefill issue with Reference Audio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,13 @@ set(GGML_BUILD_TESTS  OFF CACHE BOOL "" FORCE)
 set(GGML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
 if(S2_AUTO_APPLY_LOCAL_PATCHES)
-    find_program(S2_PATCH_EXECUTABLE patch)
+
+	if(WIN32) #Fixes issue with patch not being available in Windows builds.
+		find_program(S2_PATCH_EXECUTABLE git apply)
+	else()
+		find_program(S2_PATCH_EXECUTABLE patch)
+	endif()
+	
     if(NOT S2_PATCH_EXECUTABLE)
         message(FATAL_ERROR "S2_AUTO_APPLY_LOCAL_PATCHES=ON requires the 'patch' executable")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(GGML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 if(S2_AUTO_APPLY_LOCAL_PATCHES)
 
 	if(WIN32) #Fixes issue with patch not being available in Windows builds.
-		find_program(S2_PATCH_EXECUTABLE git apply)
+		find_program(S2_PATCH_EXECUTABLE git)
 	else()
 		find_program(S2_PATCH_EXECUTABLE patch)
 	endif()

--- a/README.md
+++ b/README.md
@@ -218,7 +218,13 @@ Updated native C# P/Invoke example: [`examples/csharp`](examples/csharp) contain
 
 Go CGo example: [`examples/golang`](examples/golang) mirrors the C# example with the same five flows (smoke, from-files, modular, legacy-stream, stream-ex) using runtime `dlopen` loading — no build-time dependency on `libs2`. Streaming callbacks use `//export` Go functions with `sync.Map` for session state, equivalent to the C# `GCHandle` pattern.
 
-Community C# wrapper: [FishS2Sharp](https://github.com/subspecs/FishS2Sharp) targets .NET Standard 2.1 and wraps the exported library API for C# / Unity-style integration.
+---
+
+## Community Made Wrappers/Ports:
+
+| Repo. Name | Language | Maintainer |
+|---|---|:---:|
+| [FishS2Sharp](https://github.com/subspecs/FishS2Sharp) | `C#` | <a href="https://github.com/subspecs" target="_blank"><center><img src="https://images.weserv.nl/?url=avatars.githubusercontent.com/u/45248469?v=4&h=35&w=35&fit=cover&mask=circle&maxage=7d" alt="SubSpecs"></center></a> |
 
 ---
 

--- a/cmake/apply_local_patches.cmake
+++ b/cmake/apply_local_patches.cmake
@@ -17,7 +17,7 @@ endif()
 foreach(_patch IN LISTS S2_PATCH_FILES)
 if(WIN32)
     execute_process(
-        COMMAND "${S2_PATCH_EXECUTABLE}" apply --stat -p1 -i "${_patch}"
+        COMMAND "${S2_PATCH_EXECUTABLE}" apply --check -p1 "${_patch}"
         WORKING_DIRECTORY "${S2_PATCH_ROOT}"
         RESULT_VARIABLE _can_apply
         OUTPUT_QUIET
@@ -56,19 +56,19 @@ endif()
 
 if(WIN32)
     execute_process(
-		COMMAND "${S2_PATCH_EXECUTABLE}" apply --stat -R -p1 "${_patch}"
+		COMMAND "${S2_PATCH_EXECUTABLE}" apply --check --reverse -p1 "${_patch}"
         WORKING_DIRECTORY "${S2_PATCH_ROOT}"
         RESULT_VARIABLE _already_applied
-        #OUTPUT_QUIET
-        #ERROR_QUIET
+        OUTPUT_QUIET
+        ERROR_QUIET
     )
 else()
     execute_process(
 		COMMAND "${S2_PATCH_EXECUTABLE}" --batch --dry-run -R -p1 -i "${_patch}"
         WORKING_DIRECTORY "${S2_PATCH_ROOT}"
         RESULT_VARIABLE _already_applied
-        #OUTPUT_QUIET
-        #ERROR_QUIET
+        OUTPUT_QUIET
+        ERROR_QUIET
     )
 endif()
 

--- a/cmake/apply_local_patches.cmake
+++ b/cmake/apply_local_patches.cmake
@@ -15,20 +15,38 @@ if(NOT S2_PATCH_FILES)
 endif()
 
 foreach(_patch IN LISTS S2_PATCH_FILES)
+if(WIN32)
     execute_process(
-        COMMAND "${S2_PATCH_EXECUTABLE}" --batch --dry-run --forward -p1 -i "${_patch}"
+        COMMAND "${S2_PATCH_EXECUTABLE}" apply --stat -p1 -i "${_patch}"
         WORKING_DIRECTORY "${S2_PATCH_ROOT}"
         RESULT_VARIABLE _can_apply
         OUTPUT_QUIET
         ERROR_QUIET
     )
+else()
+    execute_process(
+		COMMAND "${S2_PATCH_EXECUTABLE}" --batch --dry-run --forward -p1 -i "${_patch}"
+        WORKING_DIRECTORY "${S2_PATCH_ROOT}"
+        RESULT_VARIABLE _can_apply
+        OUTPUT_QUIET
+        ERROR_QUIET
+    )
+endif()
 
     if(_can_apply EQUAL 0)
+if(WIN32)
+        execute_process(
+			COMMAND "${S2_PATCH_EXECUTABLE}" apply -p1 "${_patch}"
+            WORKING_DIRECTORY "${S2_PATCH_ROOT}"
+            RESULT_VARIABLE _apply_result
+        )
+else()
         execute_process(
             COMMAND "${S2_PATCH_EXECUTABLE}" --batch --forward -p1 -i "${_patch}"
             WORKING_DIRECTORY "${S2_PATCH_ROOT}"
             RESULT_VARIABLE _apply_result
         )
+endif()
         if(NOT _apply_result EQUAL 0)
             message(FATAL_ERROR "Failed to apply local patch: ${_patch}")
         endif()
@@ -36,13 +54,23 @@ foreach(_patch IN LISTS S2_PATCH_FILES)
         continue()
     endif()
 
+if(WIN32)
     execute_process(
-        COMMAND "${S2_PATCH_EXECUTABLE}" --batch --dry-run -R -p1 -i "${_patch}"
+		COMMAND "${S2_PATCH_EXECUTABLE}" apply --stat -R -p1 "${_patch}"
         WORKING_DIRECTORY "${S2_PATCH_ROOT}"
         RESULT_VARIABLE _already_applied
-        OUTPUT_QUIET
-        ERROR_QUIET
+        #OUTPUT_QUIET
+        #ERROR_QUIET
     )
+else()
+    execute_process(
+		COMMAND "${S2_PATCH_EXECUTABLE}" --batch --dry-run -R -p1 -i "${_patch}"
+        WORKING_DIRECTORY "${S2_PATCH_ROOT}"
+        RESULT_VARIABLE _already_applied
+        #OUTPUT_QUIET
+        #ERROR_QUIET
+    )
+endif()
 
     if(_already_applied EQUAL 0)
         message(STATUS "Local patch already applied: ${_patch}")

--- a/include/s2_model.h
+++ b/include/s2_model.h
@@ -109,6 +109,14 @@ public:
 
     void clear_kv_cache();
 
+private:
+    bool eval_cached(const std::vector<int32_t> & flat_tokens,
+        int32_t n_tokens, int32_t n_threads,
+        StepResult & result);
+public:
+    bool prefill_fast(const std::vector<int32_t> & flat_tokens, int32_t n_tokens,
+        int32_t n_threads, StepResult & result);
+
     bool prefill(const std::vector<int32_t> & flat_tokens, int32_t n_tokens,
                  int32_t n_threads, StepResult & result);
 
@@ -143,9 +151,6 @@ private:
 
     std::unordered_set<ggml_tensor *> weight_tensor_set_;
 
-    bool eval_cached(const std::vector<int32_t> & flat_tokens,
-                     int32_t n_tokens, int32_t n_threads,
-                     StepResult & result);
 };
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,7 +203,11 @@ int main(int argc, char** argv) {
         }
         else if (arg == "--codec-context-frames") {
             if (i+1 < argc) {
+#ifdef WIN32
+                try { params.codec_decode_context_frames = max(0, std::stoi(argv[++i])); } catch(...) {}
+#else
                 try { params.codec_decode_context_frames = std::max(0, std::stoi(argv[++i])); } catch(...) {}
+#endif
             }
         }
         else if (arg == "--log-level") {

--- a/src/s2_export_api.cpp
+++ b/src/s2_export_api.cpp
@@ -333,7 +333,11 @@ private:
             on_error("Streaming callback on_wav_chunk is required");
             return false;
         }
+#ifdef WIN32 //Fixes conflict of #max defines for MSVC builds.
+        if (size > static_cast<size_t>(INT_MAX)) {
+#else
         if (size > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+#endif
             on_error("Streaming chunk exceeds int32 size limit");
             return false;
         }

--- a/src/s2_generate.cpp
+++ b/src/s2_generate.cpp
@@ -48,7 +48,7 @@ GenerateResult generate(
         std::cout << "[Generate] Prefilling " << prompt.cols << " tokens..." << std::endl;
     }
     const auto prefill_t0 = std::chrono::steady_clock::now();
-    if (!model.prefill(prompt_tm, prompt.cols, params.n_threads, state)) {
+    if (!model.prefill_fast(prompt_tm, prompt.cols, params.n_threads, state)) {
         std::cerr << "[Generate] Prefill failed." << std::endl;
         return out;
     }

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -785,6 +785,10 @@ void SlowARModel::clear_kv_cache() {
     max_seq_len_ = 0;
     n_past_ = 0;
 }
+bool SlowARModel::prefill_fast(const std::vector<int32_t> & flat_tokens, int32_t n_tokens,
+                          int32_t n_threads, StepResult & result) {
+    return eval_cached(flat_tokens, n_tokens, n_threads, result);
+}
 
 bool SlowARModel::prefill(const std::vector<int32_t> & flat_tokens, int32_t n_tokens,
                           int32_t n_threads, StepResult & result) {


### PR DESCRIPTION
So I noticed that now using a pre-processed reference audio slows down the entire generation process from around 7s last time to now around 33s+. This is insane, wtf happened these past two weeks?
This doesn't happen without any reference audio.

I tracked down the issue and found that mode.prefill() was the culprit.
Honestly I think model prefilling should be optional and we should have an option to turn it off per generation.
For now, I created a "prefill_fast()" method(check commit) that reduces the time from 33s per generation down to about 9s per generation:
<img width="978" height="675" alt="image" src="https://github.com/user-attachments/assets/64114dca-2319-4c83-b078-589307138de0" />

The output sample is literally identical regardless if using _fast or default method, yet performance ins roughly 3x faster.
