### PR TITLE
Fix MSVC math library link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ if(S2_METAL AND NOT APPLE)
     message(FATAL_ERROR "S2_METAL is only supported on Apple platforms.")
 endif()
 
+# MSVC provides math functions through the CRT and does not ship a separate
+# libm. Some ggml CMake revisions still probe for "m" and can propagate
+# MATH_LIBRARY-NOTFOUND into the generated Visual Studio linker inputs.
+if(MSVC)
+    set(MATH_LIBRARY "" CACHE FILEPATH "MSVC does not require a separate math library." FORCE)
+endif()
+
 set(GGML_BUILD_TESTS  OFF CACHE BOOL "" FORCE)
 set(GGML_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 


### PR DESCRIPTION
  ## Summary

  Fixes the MSVC Windows CMake issue where `ggml-base` could receive `MATH_LIBRARY-NOTFOUND.lib` as a linker dependency.

  On MSVC, math functions are provided by the Visual Studio CRT, so there is no separate `libm`/`m` library to link. The top-level CMake now sets `MATH_LIBRARY` to an empty
  cache value for MSVC before loading `ggml`, preventing `MATH_LIBRARY-NOTFOUND` from propagating into generated Visual Studio projects.

  This PR also brings `staging` up to date with `main`.

  ## Verification

  - Configured and built CPU Release successfully:
    - `cmake -S . -B build-cpu -DCMAKE_BUILD_TYPE=Release -DS2_AUTO_APPLY_LOCAL_PATCHES=ON -DS2_VULKAN=OFF`
    - `cmake --build build-cpu --config Release`
  - Configured and built Vulkan Release successfully:
    - `cmake -S . -B build-vulkan -DCMAKE_BUILD_TYPE=Release -DS2_AUTO_APPLY_LOCAL_PATCHES=ON -DS2_VULKAN=ON`
    - `cmake --build build-vulkan --config Release`
  - Verified both binaries with `s2 --help`
  - Confirmed no generated `MATH_LIBRARY-NOTFOUND` / `NOTFOUND.lib` entries in `build-cpu` or `build-vulkan`