### PR TITLE
fix: segmentation fault on Vulkan (gfx1031 radv)

### DIFF
--- a/src/s2_generate.cpp
+++ b/src/s2_generate.cpp
@@ -48,7 +48,8 @@ GenerateResult generate(
         std::cout << "[Generate] Prefilling " << prompt.cols << " tokens..." << std::endl;
     }
     const auto prefill_t0 = std::chrono::steady_clock::now();
-    if (!model.prefill_fast(prompt_tm, prompt.cols, params.n_threads, state)) {
+    // using prefill_fast causes segfault on vulkan with specific architectures (RDNA2 radv gfx 1031)
+    if (!model.prefill(prompt_tm, prompt.cols, params.n_threads, state)) {
         std::cerr << "[Generate] Prefill failed." << std::endl;
         return out;
     }


### PR DESCRIPTION
- Calling prefill_fast causes segmentation faults in Archlinux when using on an RX 6700 (Latest radv as of this PR). 

- Reproducible by loading any layers to GPU when using Vulkan. YMMV between different GPU architectures and driver versions, this was the only way to successfully generate for me. 

- 0 layers on GPU or compiling for CPU backend fixes/works around this, but that essentially disables GPU benefit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated text generation to use the standard prefill process, improving consistency and reliability during prompt processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->