### PR TITLE
feat: Backend-specific prefill chunk sizes

### DIFF
--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -819,19 +819,41 @@ bool SlowARModel::prefill(const std::vector<int32_t> & flat_tokens, int32_t n_to
             // Vulkan: Limited by ggml_soft_max shader workgroup/shared memory limits
             // CUDA/Metal: Highly optimized soft_max kernels handle large batches
             // CPU: Memory bandwidth bound, scale with available parallelism
-            int32_t adaptive_gpu_chunk = 64; // Safe fallback
-
-#if defined(GGML_USE_CUDA) || defined(GGML_USE_METAL)
-            adaptive_gpu_chunk = 512;
-#elif defined(GGML_USE_VULKAN)
-            adaptive_gpu_chunk = 64;
-#else
-            // CPU or unknown backend: scale with thread count, capped at 256
-            adaptive_gpu_chunk = std::min(256, std::max(64, n_threads * 16));
-#endif
-
-            if (n_tokens > adaptive_gpu_chunk) {
-                chunk_tokens = adaptive_gpu_chunk;
+            int32_t adaptive_chunk = std::min<int32_t>(256, std::max<int32_t>(64, resolve_n_threads(n_threads) * 16));
+        
+            if (backend_gpu_ != nullptr && n_gpu_layers_ > 0) {
+                const char * backend_name = ggml_backend_name(backend_gpu_);
+                if (backend_name != nullptr) {
+                    std::string name(backend_name);
+                    if (name.find("CUDA") != std::string::npos ||
+                        name.find("Metal") != std::string::npos) {
+                        adaptive_chunk = 512;
+                    } else if (name.find("Vulkan") != std::string::npos) {
+                        adaptive_chunk = 64;
+                    }
+                }
+        
+                int32_t semantic_prompt_tokens = 0;
+                for (int32_t t = 0; t < n_tokens; ++t) {
+                    const int32_t semantic = flat_tokens[static_cast<size_t>(t) * codebook_dim];
+                    if (semantic >= hparams_.semantic_begin_id &&
+                        semantic <= hparams_.semantic_end_id) {
+                        semantic_prompt_tokens++;
+                        if (semantic_prompt_tokens > 1) {
+                            break;
+                        }
+                    }
+                }
+        
+                if (semantic_prompt_tokens > 1 &&
+                    backend_requires_single_token_semantic_prefill(backend_gpu_)) {
+                    adaptive_chunk = 1;
+                }
+            }
+        
+            int32_t chunk_tokens = n_tokens;
+            if (n_tokens > adaptive_chunk) {
+                chunk_tokens = adaptive_chunk;
             }
         }
     }

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -815,12 +815,21 @@ bool SlowARModel::prefill(const std::vector<int32_t> & flat_tokens, int32_t n_to
             backend_requires_single_token_semantic_prefill(backend_gpu_)) {
             chunk_tokens = 1;
         } else {
+            // Backend-specific prefill chunk sizes for naive attention path.
+            // Vulkan: Limited by ggml_soft_max shader workgroup/shared memory limits
+            // CUDA/Metal: Highly optimized soft_max kernels handle large batches
+            // CPU: Memory bandwidth bound, scale with available parallelism
+            int32_t adaptive_gpu_chunk = 64; // Safe fallback
 
-            const int32_t adaptive_gpu_chunk = std::clamp(
-                128 / std::max(1, n_gpu_layers_),
-                8,
-                64
-            );
+#if defined(GGML_USE_CUDA) || defined(GGML_USE_METAL)
+            adaptive_gpu_chunk = 512;
+#elif defined(GGML_USE_VULKAN)
+            adaptive_gpu_chunk = 64;
+#else
+            // CPU or unknown backend: scale with thread count, capped at 256
+            adaptive_gpu_chunk = std::min(256, std::max(64, n_threads * 16));
+#endif
+
             if (n_tokens > adaptive_gpu_chunk) {
                 chunk_tokens = adaptive_gpu_chunk;
             }


### PR DESCRIPTION
- The default adaptive_gpu_chunk is too conservative, For example it'd fire up 28 times for 204 tokens causing large delays in prefill with 800 ms~ latency if used with #40 only in blocks of 8.
- By using larger chunk sizes that are adjusted for each backend, we can safely decrease this delay (from 872 ms to 378 ms, both with FA) to increase performance.

Before PR (FA disabled, no chunking for some reason, optimal prefill delay):
```
[Generate] Prefilling 204 tokens...
[Generate] Generating (max 1024 tokens)...
[Generate] 50 / 1024 tokens...
[Generate] Done: 55 frames generated.
[Metrics] Generate: prefill=274.399 ms, loop=3596.74 ms, total=3873.83 ms, avg=65.3952 ms/frame
```

After PR (FA disabled, chunk preset of 64 for Vulkan):
```
Generate] Prefilling 204 tokens...
[Model] Chunked prefill: 204 tokens in blocks of 64
[Generate] Generating (max 1024 tokens)...
[Generate] 50 / 1024 tokens...
[Generate] Done: 53 frames generated.
[Metrics] Generate: prefill=384.687 ms, loop=3426.41 ms, total=3813.65 ms, avg=64.6492 ms/frame
```


Before PR (FA enabled):
```
[Generate] Prefilling 204 tokens...
[Model] Chunked prefill: 204 tokens in blocks of 8
[Generate] Generating (max 1024 tokens)...
[Generate] 50 / 1024 tokens...
[Generate] Done: 60 frames generated.
[Metrics] Generate: prefill=872.475 ms, loop=3251.56 ms, total=4126.58 ms, avg=54.1927 ms/frame
```

After PR (FA enabled):
```
[Generate] Prefilling 204 tokens...
[Model] Chunked prefill: 204 tokens in blocks of 64
[Generate] Generating (max 1024 tokens)...
[Generate] 50 / 1024 tokens...
[Generate] Done: 58 frames generated.
[Metrics] Generate: prefill=378.19 ms, loop=3241.61 ms, total=3622.34 ms, avg=55.8898 ms/frame
```

Don't mind the small difference in average and loop. There was some background usage so not a neat/clean comparison, the massive 500 ms~ prefill difference is what I wanted to showcase.

I'm unable to test on cuda or metal, and some higher numbers causes segmentation faults on Vulkan perhaps a driver or ggml-vulkan issue. However those should be more stable? 

Needs testing by anyone with the hardware to determine if they're stable and which values might benefit performance more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved prompt processing by selecting more appropriate prefill chunk sizes based on available CPU threads and the active hardware backend.
  * Adjusted chunking behavior for special prompt scenarios to ensure correct and efficient prefill handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->