### PR TITLE
feat: Flash Attention and modernized KV Cache layout for Slow-AR

### DIFF
--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -478,23 +478,23 @@ bool SlowARModel::load_shared(gguf_context * ctx_gguf, const std::string & gguf_
 
     weight_tensor_set_.insert(weight_tensors.begin(), weight_tensors.end());
 
-        const bool full_model_offload =
-            backend_gpu_ != nullptr &&
-            backend_type != BackendType::CUDA &&
-                        n_gpu_layers_ == hparams_.block_count;
+    const bool full_model_offload =
+        backend_gpu_ != nullptr &&
+        backend_type != BackendType::CUDA &&
+        n_gpu_layers_ == hparams_.block_count;
 
-        auto get_weight_backend = [&](const std::string & name) -> ggml_backend_t {
-            
-            if (full_model_offload) {
+    auto get_weight_backend = [&](const std::string & name) -> ggml_backend_t {
+
+        if (full_model_offload) {
             return backend_gpu_;
         }
 
-                if (name == "embeddings.weight" ||
-                    name == "codebook_embeddings.weight" ||
-                    name == "fast_embeddings.weight" ||
-                    name == "norm.weight") {
-                    return backend_cpu_;
-                            }
+        if (name == "embeddings.weight" ||
+            name == "codebook_embeddings.weight" ||
+            name == "fast_embeddings.weight" ||
+            name == "norm.weight") {
+            return backend_cpu_;
+        }
 
         if (name.rfind("fast_layers.", 0) == 0 ||
             name.rfind("fast_", 0) == 0) {
@@ -961,7 +961,7 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
         x = ggml_mul(ctx0, x, ggml_repeat(ctx0, token_scale, x));
     }
 
-        for (int32_t il = 0; il < hparams_.block_count; ++il) {
+    for (int32_t il = 0; il < hparams_.block_count; ++il) {
         const auto & layer = weights_.layers[il];
 
         ggml_tensor * attn_in = rms_norm_weighted(ctx0, x, layer.attention_norm, hparams_.rms_norm_eps);

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -478,23 +478,23 @@ bool SlowARModel::load_shared(gguf_context * ctx_gguf, const std::string & gguf_
 
     weight_tensor_set_.insert(weight_tensors.begin(), weight_tensors.end());
 
-    const bool full_model_offload =
-        backend_gpu_ != nullptr &&
-        backend_type != BackendType::CUDA &&
-        n_gpu_layers_ == hparams_.block_count;
+        const bool full_model_offload =
+            backend_gpu_ != nullptr &&
+            backend_type != BackendType::CUDA &&
+                        n_gpu_layers_ == hparams_.block_count;
 
-    auto get_weight_backend = [&](const std::string & name) -> ggml_backend_t {
-
-        if (full_model_offload) {
+        auto get_weight_backend = [&](const std::string & name) -> ggml_backend_t {
+            
+            if (full_model_offload) {
             return backend_gpu_;
         }
 
-        if (name == "embeddings.weight" ||
-            name == "codebook_embeddings.weight" ||
-            name == "fast_embeddings.weight" ||
-            name == "norm.weight") {
-            return backend_cpu_;
-        }
+                if (name == "embeddings.weight" ||
+                    name == "codebook_embeddings.weight" ||
+                    name == "fast_embeddings.weight" ||
+                    name == "norm.weight") {
+                    return backend_cpu_;
+                            }
 
         if (name.rfind("fast_layers.", 0) == 0 ||
             name.rfind("fast_", 0) == 0) {
@@ -743,8 +743,9 @@ bool SlowARModel::init_kv_cache(int32_t max_seq_len) {
         return false;
     }
 
-    memory_k_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, n_head_kv, max_seq_len, n_layer);
-    memory_v_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, n_head_kv, max_seq_len, n_layer);
+    // Layout for flash attention
+    memory_k_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, max_seq_len, n_head_kv, n_layer);
+    memory_v_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, max_seq_len, n_head_kv, n_layer);
 
     ggml_backend_t kv_backend = (n_gpu_layers_ > 0 && backend_gpu_) ? backend_gpu_ : backend_cpu_;
     kv_buf_ = ggml_backend_alloc_ctx_tensors(ctx_kv_, kv_backend);
@@ -952,7 +953,6 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
     }
 
     if (codebook_sum != nullptr) {
-
         codebook_sum = ggml_mul(ctx0, codebook_sum,
                                 ggml_repeat(ctx0, semantic_mask, codebook_sum));
         x = ggml_add(ctx0, x, codebook_sum);
@@ -961,7 +961,7 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
         x = ggml_mul(ctx0, x, ggml_repeat(ctx0, token_scale, x));
     }
 
-    for (int32_t il = 0; il < hparams_.block_count; ++il) {
+        for (int32_t il = 0; il < hparams_.block_count; ++il) {
         const auto & layer = weights_.layers[il];
 
         ggml_tensor * attn_in = rms_norm_weighted(ctx0, x, layer.attention_norm, hparams_.rms_norm_eps);
@@ -990,53 +990,86 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
 
         const size_t layer_off_k = static_cast<size_t>(il) * memory_k_->nb[3];
         const size_t layer_off_v = static_cast<size_t>(il) * memory_v_->nb[3];
-        const size_t token_off_k = static_cast<size_t>(n_past_) * memory_k_->nb[2];
-        const size_t token_off_v = static_cast<size_t>(n_past_) * memory_v_->nb[2];
+        const size_t token_off_k = static_cast<size_t>(n_past_) * memory_k_->nb[1];
+        const size_t token_off_v = static_cast<size_t>(n_past_) * memory_v_->nb[1];
 
         ggml_tensor * k_slot = ggml_view_3d(ctx0, memory_k_,
-            head_dim, n_head_kv, n_tokens,
+            head_dim, n_tokens, n_head_kv,
             memory_k_->nb[1], memory_k_->nb[2],
             layer_off_k + token_off_k);
         ggml_tensor * v_slot = ggml_view_3d(ctx0, memory_v_,
-            head_dim, n_head_kv, n_tokens,
+            head_dim, n_tokens, n_head_kv,
             memory_v_->nb[1], memory_v_->nb[2],
             layer_off_v + token_off_v);
-        ggml_build_forward_expand(gf, ggml_cpy(ctx0, k, k_slot));
-        ggml_build_forward_expand(gf, ggml_cpy(ctx0, v, v_slot));
+            
+        // Permute k and v to match the cache layout
+        ggml_tensor * k_perm = ggml_cont(ctx0, ggml_permute(ctx0, k, 0, 2, 1, 3));
+        ggml_tensor * v_perm = ggml_cont(ctx0, ggml_permute(ctx0, v, 0, 2, 1, 3));
 
-        ggml_tensor * k_mem = k;
-        ggml_tensor * v_mem = v;
-        if (n_past_ > 0) {
-            ggml_tensor * k_past = ggml_reshape_3d(ctx0,
-                ggml_view_1d(ctx0, memory_k_, static_cast<int64_t>(n_past_) * kv_size, layer_off_k),
-                head_dim, n_head_kv, n_past_);
-            ggml_tensor * v_past = ggml_reshape_3d(ctx0,
-                ggml_view_1d(ctx0, memory_v_, static_cast<int64_t>(n_past_) * kv_size, layer_off_v),
-                head_dim, n_head_kv, n_past_);
-            if (k_past->type != k->type) k_past = ggml_cast(ctx0, k_past, k->type);
-            if (v_past->type != v->type) v_past = ggml_cast(ctx0, v_past, v->type);
-            k_mem = ggml_concat(ctx0, k_past, k, 2);
-            v_mem = ggml_concat(ctx0, v_past, v, 2);
+        ggml_build_forward_expand(gf, ggml_cpy(ctx0, k_perm, k_slot));
+        ggml_build_forward_expand(gf, ggml_cpy(ctx0, v_perm, v_slot));
+
+        ggml_tensor * attn_cur = nullptr;
+
+        if (n_tokens == 1) {
+            // Flash attention path
+            ggml_tensor * Q = ggml_permute(ctx0, q, 0, 2, 1, 3);
+
+            ggml_tensor * k_cache = ggml_view_3d(ctx0, memory_k_,
+                head_dim, n_past_ + 1, n_head_kv,
+                memory_k_->nb[1], memory_k_->nb[2], layer_off_k);
+
+            ggml_tensor * v_cache = ggml_view_3d(ctx0, memory_v_,
+                head_dim, n_past_ + 1, n_head_kv,
+                memory_v_->nb[1], memory_v_->nb[2], layer_off_v);
+
+            ggml_tensor * attn_fa = ggml_flash_attn_ext(
+                ctx0, Q, k_cache, v_cache, nullptr, attn_scale, 0.0f, 0.0f);
+            
+            ggml_tensor * attn_merged = ggml_permute(ctx0, attn_fa, 0, 2, 1, 3);
+            
+            // ggml_cpy safely handles reading from the permuted view into a fresh 2D tensor.
+            attn_cur = ggml_cpy(ctx0, attn_merged,
+                ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
+        } else {
+            // Prefill path (keep concat logic)
+            ggml_tensor * k_mem = k;
+            ggml_tensor * v_mem = v;
+            if (n_past_ > 0) {
+                ggml_tensor * k_past_view = ggml_view_3d(ctx0, memory_k_,
+                    head_dim, n_past_, n_head_kv,
+                    memory_k_->nb[1], memory_k_->nb[2], layer_off_k);
+                ggml_tensor * v_past_view = ggml_view_3d(ctx0, memory_v_,
+                    head_dim, n_past_, n_head_kv,
+                    memory_v_->nb[1], memory_v_->nb[2], layer_off_v);
+                
+                ggml_tensor * k_past = ggml_cont(ctx0, ggml_permute(ctx0, k_past_view, 0, 2, 1, 3));
+                ggml_tensor * v_past = ggml_cont(ctx0, ggml_permute(ctx0, v_past_view, 0, 2, 1, 3));
+
+                if (k_past->type != k->type) k_past = ggml_cast(ctx0, k_past, k->type);
+                if (v_past->type != v->type) v_past = ggml_cast(ctx0, v_past, v->type);
+                
+                k_mem = ggml_concat(ctx0, k_past, k, 2);
+                v_mem = ggml_concat(ctx0, v_past, v, 2);
+            }
+            if (n_head != n_head_kv && q->type != GGML_TYPE_F32) {
+                q = ggml_cast(ctx0, q, GGML_TYPE_F32);
+            }
+            ggml_tensor * k_rep = repeat_interleave_heads(ctx0, k_mem, n_head / n_head_kv);
+            ggml_tensor * v_rep = repeat_interleave_heads(ctx0, v_mem, n_head / n_head_kv);
+            ggml_tensor * Q   = ggml_permute(ctx0, q,     0, 2, 1, 3);
+            ggml_tensor * K   = ggml_permute(ctx0, k_rep, 0, 2, 1, 3);
+            ggml_tensor * KQ  = mul_mat_checked(ctx0, K, Q, "mul_mat:kq");
+            ggml_tensor * KQs = ggml_scale(ctx0, KQ, attn_scale);
+            ggml_tensor * KQm = ggml_diag_mask_inf(ctx0, KQs, n_past_);
+            ggml_tensor * KQf = ggml_soft_max(ctx0, KQm);
+            ggml_tensor * V       = ggml_cont(ctx0, ggml_permute(ctx0, v_rep, 1, 2, 0, 3));
+            ggml_tensor * KQV     = mul_mat_checked(ctx0, V, KQf, "mul_mat:kqv");
+            ggml_tensor * KQVm    = ggml_permute(ctx0, KQV, 0, 2, 1, 3);
+            attn_cur = ggml_cpy(ctx0, KQVm,
+                ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
         }
 
-        if (n_head != n_head_kv && q->type != GGML_TYPE_F32) {
-            q = ggml_cast(ctx0, q, GGML_TYPE_F32);
-        }
-        ggml_tensor * k_rep = repeat_interleave_heads(ctx0, k_mem, n_head / n_head_kv);
-        ggml_tensor * v_rep = repeat_interleave_heads(ctx0, v_mem, n_head / n_head_kv);
-
-        ggml_tensor * Q   = ggml_permute(ctx0, q,     0, 2, 1, 3);
-        ggml_tensor * K   = ggml_permute(ctx0, k_rep, 0, 2, 1, 3);
-        ggml_tensor * KQ  = mul_mat_checked(ctx0, K, Q, "mul_mat:kq");
-        ggml_tensor * KQs = ggml_scale(ctx0, KQ, attn_scale);
-        ggml_tensor * KQm = ggml_diag_mask_inf(ctx0, KQs, n_past_);
-        ggml_tensor * KQf = ggml_soft_max(ctx0, KQm);
-
-        ggml_tensor * V       = ggml_cont(ctx0, ggml_permute(ctx0, v_rep, 1, 2, 0, 3));
-        ggml_tensor * KQV     = mul_mat_checked(ctx0, V, KQf, "mul_mat:kqv");
-        ggml_tensor * KQVm    = ggml_permute(ctx0, KQV, 0, 2, 1, 3);
-        ggml_tensor * attn_cur = ggml_cpy(ctx0, KQVm,
-                                          ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
         ggml_tensor * attn_out = mul_mat_checked(ctx0, layer.wo, attn_cur, "mul_mat:wo");
 
         ggml_tensor * h     = ggml_add(ctx0, x, attn_out);

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -1026,11 +1026,9 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
             ggml_tensor * attn_fa = ggml_flash_attn_ext(
                 ctx0, Q, k_cache, v_cache, nullptr, attn_scale, 0.0f, 0.0f);
             
-            ggml_tensor * attn_merged = ggml_permute(ctx0, attn_fa, 0, 2, 1, 3);
-            
-            // ggml_cpy safely handles reading from the permuted view into a fresh 2D tensor.
-            attn_cur = ggml_cpy(ctx0, attn_merged,
-                ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
+            // attn_fa is [head_dim, n_head, n_tokens=1, 1]; with n_tokens==1 no reorder is needed.
+            attn_cur = ggml_cpy(ctx0, attn_fa,
+                 ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
         } else {
             // Prefill path (keep concat logic)
             ggml_tensor * k_mem = k;


### PR DESCRIPTION
- 17% speedup on Q8  (per-frame ms)
- Allows for longer text input before OOM. For example, 593 prefill + 1000/1024 tokens crashes on non-FA version, while FA consumes far less VRAM allowing for successful completion (10 GB RX 6700 Vulkan, 1.5 GB background usage, Archlinux)

The only downside is that prefill takes significantly longer unless you're also using #39 with which it's negligible.

Here are some numbers:
WITH #39 (Notice smaller prefill gap):
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/ecf8b028-337e-488c-bcf7-fbc01d4c22fe" />

<details><summary>FA run #39 :</summary>
<p>

> [Metrics] Init: tokenizer=232,325471 ms, model=20,368374 ms, codec=11200,593645 ms (Vulkan0), total=11458,379596 ms, max_rss=631,917969 MB
> Loading voice profile: 69
> Loaded voice profile: 69 (134 frames)
> --- Pipeline Synthesize ---
> Text: hello world, how are you today?
> [Model] KV cache allocated on Vulkan0, size: 172.688 MB
> [Generate] Prefilling 204 tokens...
> [Model] Chunked prefill: 204 tokens in blocks of 64
> [Generate] Generating (max 1024 tokens)...
> [Generate] 50 / 1024 tokens...
> [Generate] Done: 58 frames generated.
> [Metrics] Generate: prefill=378.19 ms, loop=3241.61 ms, total=3622.34 ms, avg=55.8898 ms/frame
> [Metrics] Synthesis: frames=58, audio_s=2,693515, ref_encode=0,000000 ms, kv_init=4,852855 ms, generate=3622,358779 ms, decode=652,069728 ms, decode_wall=652,103110 ms, decode_batches=1, decode_stride=16 frames, total=4279,762568 ms, gen_avg=62,454462 ms/frame, total_avg=73,789010 ms/frame, gen_rtf=1,344845, total_rtf=1,588914, max_rss=631,917969 MB

</p>
</details> 

<details><summary>no FA run #39 :</summary>
<p>

> [Metrics] Init: tokenizer=244,556109 ms, model=19,648296 ms,
> codec=11091,179776 ms (Vulkan0), total=11357,319675 ms,
> max_rss=633,492188 MB
> Loading voice profile: 69
> Loaded voice profile: 69 (134 frames)
> --- Pipeline Synthesize ---
> Text: hello world, how are you today?
> [Model] KV cache allocated on Vulkan0, size: 172.688 MB
> [Generate] Prefilling 204 tokens...
> [Generate] Generating (max 1024 tokens)...
> [Generate] 50 / 1024 tokens...
> [Generate] Done: 55 frames generated.
> [Metrics] Generate: prefill=274.399 ms, loop=3596.74 ms, total=3873.83 ms, avg=65.3952 ms/frame
> [Metrics] Synthesis: frames=55, audio_s=2,554195, ref_encode=0,000000
> ms, kv_init=7,245439 ms, generate=3873,850302 ms, decode=614,090191 ms,
> decode_wall=614,120076 ms, decode_batches=1, decode_stride=16 frames,
> total=4495,618254 ms, gen_avg=70,433642 ms/frame, total_avg=81,738514
> ms/frame, gen_rtf=1,516662, total_rtf=1,760092, max_rss=633,492188 MB 

</p>
</details> 

WITHOUT #39 (bigger prefill gap which #39 remedies & longer text showcases growing gap with FA ahead) :
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/53e96956-4227-4d2b-8084-90315301f00e" />



<details><summary>FA run:</summary>
<p>

>  [Metrics] Init: tokenizer=234,274231 ms, model=19,048437 ms,
> codec=11234,416737 ms (Vulkan0), total=11489,671653 ms,
> max_rss=631,949219 MB
> Loading voice profile: 69
> Loaded voice profile: 69 (134 frames)
> --- Pipeline Synthesize ---
> Text: hello world, how are you today? I hope you're doing good,
> relatively speaking. What is doing good and who came up with it anyways?
> [Model] KV cache allocated on Vulkan0, size: 175.781 MB
> [Generate] Prefilling 226 tokens...
> [Model] Chunked prefill: 226 tokens in blocks of 8
> [Generate] Generating (max 1024 tokens)...
> [Generate] 200 / 1024 tokens...
> [Generate] Done: 206 frames generated.
> [Metrics] Generate: prefill=963.529 ms, loop=11083.1 ms, total=12049.1 ms, avg=53.8013 ms/frame
> [Metrics] Synthesis: frames=206, audio_s=9,566621, ref_encode=0,000000
> ms, kv_init=8,704014 ms, generate=12049,148369 ms, decode=10677,101339
> ms, decode_wall=10677,214061 ms, decode_batches=5, decode_stride=16
> frames, total=22735,440749 ms, gen_avg=58,491011 ms/frame,
> total_avg=110,366217 ms/frame, gen_rtf=1,259499, total_rtf=2,376538,
> max_rss=631,949219 MB

</p>
</details> 



<details><summary>no FA run:</summary>
<p>

> [Metrics] Init: tokenizer=237,676438 ms, model=19,685375 ms,
> codec=11381,829297 ms (Vulkan0), total=11641,658635 ms,
> max_rss=631,691406 MB
> Loading voice profile: 69
> Loaded voice profile: 69 (134 frames)
> --- Pipeline Synthesize ---
> Text: hello world, how are you today? I hope you're doing good,
> relatively speaking. What is doing good and who came up with it anyways?
> [Model] KV cache allocated on Vulkan0, size: 175.781 MB
> [Generate] Prefilling 226 tokens...
> [Generate] Generating (max 1024 tokens)...
> [Generate] 200 / 1024 tokens...
> [Generate] Done: 220 frames generated.
> [Metrics] Generate: prefill=308.885 ms, loop=15580.2 ms, total=15891.7 ms, avg=70.8192 ms/frame
> [Metrics] Synthesis: frames=220, audio_s=10,216780, ref_encode=0,000000
> ms, kv_init=5,445922 ms, generate=15891,673671 ms, decode=13403,478807
> ms, decode_wall=13403,608681 ms, decode_batches=6, decode_stride=16
> frames, total=29301,117276 ms, gen_avg=72,234880 ms/frame,
> total_avg=133,186897 ms/frame, gen_rtf=1,555448, total_rtf=2,867941,
> max_rss=631,691406 MB
> Saved audio to: output.wav 

</p>
</details> 

As you can see, the gap increases between them the longer your text is. FA doesn't only allow longer text with smaller memory footprint it also speeds things up. If you TTS many short sentences consecutively you will definitely want #39 .

First graph text was       

> hello world, how are you today?

Second graph text was 

> hello world, how are you today? I hope you're doing good, relatively speaking. What is doing good and who came up with it anyways?


https://hazyresearch.stanford.edu/blog/2023-01-12-flashattention-long-sequences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Performance**
  - Improved attention execution for single-token generation with a dedicated fast path.
  - Enhanced key-value cache layout and update behavior to improve attention throughput and consistency.
  - Refined handling of cached past context for more efficient attention computation.
- **Compatibility**
  - Maintains existing model weight placement and hardware offload behavior.
- **Documentation**
  - Updated notes clarifying the key-value cache layout used to support accelerated attention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->