### PR TITLE
perf:  Conditional gallocr caching for Fast-AR decode on pure CPU runs (%4~ faster)

### DIFF
--- a/include/s2_model.h
+++ b/include/s2_model.h
@@ -138,6 +138,7 @@ private:
     ggml_backend_t backend_gpu_  = nullptr;
     ggml_backend_sched_t sched_       = nullptr;
     ggml_backend_sched_t fast_sched_  = nullptr;
+    ggml_gallocr_t fast_gallocr_ = nullptr;
     ggml_context * ctx_kv_      = nullptr;
     ggml_backend_buffer_t kv_buf_ = nullptr;
     ggml_tensor *  memory_k_   = nullptr;

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -183,9 +183,16 @@ static bool allocate_weight_buffers(ggml_backend_t backend,
     return true;
 }
 
-SlowARModel::SlowARModel() {}
+SlowARModel::SlowARModel()
+    : fast_gallocr_(nullptr)
+{}
 
 SlowARModel::~SlowARModel() {
+    if (fast_gallocr_) {
+        ggml_gallocr_free(fast_gallocr_);
+        fast_gallocr_ = nullptr;
+    }
+
     if (fast_sched_)     ggml_backend_sched_free(fast_sched_);
     if (sched_)          ggml_backend_sched_free(sched_);
 
@@ -1223,33 +1230,67 @@ bool SlowARModel::fast_decode(const std::vector<float> & hidden_in,
     ggml_build_forward_expand(gf, logits);
 
     ggml_backend_cpu_set_n_threads(backend_cpu_, resolve_n_threads(n_threads));
-    ggml_backend_sched_reset(fast_sched_);
 
-    if (!ggml_backend_sched_alloc_graph(fast_sched_, gf)) {
-        std::fprintf(stderr, "[fast_decode] sched alloc failed\n");
+    // If no GPU layers are offloaded, use gallocr cached buffer pool.
+    // If GPU offload is active, use the scheduler to safely handle PCIe transfers.
+    const bool is_cpu_only = (n_gpu_layers_ == 0 || backend_gpu_ == nullptr);
+
+    if (is_cpu_only) {
+        if (!fast_gallocr_) {
+            fast_gallocr_ = ggml_gallocr_new(ggml_backend_get_default_buffer_type(backend_cpu_));
+            if (!fast_gallocr_) {
+                std::fprintf(stderr, "[fast_decode] gallocr creation failed\n");
+                ggml_free(ctx0);
+                return false;
+            }
+        }
+
+        if (!ggml_gallocr_alloc_graph(fast_gallocr_, gf)) {
+            std::fprintf(stderr, "[fast_decode] gallocr alloc failed\n");
+            ggml_free(ctx0);
+            return false;
+        }
+
+        ggml_backend_tensor_set(hidden0, hidden_in.data(), 0, hidden_in.size() * sizeof(float));
+        ggml_backend_tensor_set(positions, pos_vals.data(), 0, pos_vals.size() * sizeof(int32_t));
+        if (prefix_ids) {
+            ggml_backend_tensor_set(prefix_ids, prefix_tokens.data(), 0, prefix_tokens.size() * sizeof(int32_t));
+        }
+
+        if (ggml_backend_graph_compute(backend_cpu_, gf) != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "[fast_decode] cpu compute failed\n");
+            ggml_free(ctx0);
+            return false;
+        }
+    } else {
         ggml_backend_sched_reset(fast_sched_);
-        ggml_free(ctx0);
-        return false;
-    }
 
-    ggml_backend_tensor_set(hidden0,   hidden_in.data(),    0, hidden_in.size() * sizeof(float));
-    ggml_backend_tensor_set(positions, pos_vals.data(),     0, pos_vals.size() * sizeof(int32_t));
-    if (prefix_ids) {
-        ggml_backend_tensor_set(prefix_ids, prefix_tokens.data(), 0,
-                                prefix_tokens.size() * sizeof(int32_t));
-    }
+        if (!ggml_backend_sched_alloc_graph(fast_sched_, gf)) {
+            std::fprintf(stderr, "[fast_decode] sched alloc failed\n");
+            ggml_backend_sched_reset(fast_sched_);
+            ggml_free(ctx0);
+            return false;
+        }
 
-    if (ggml_backend_sched_graph_compute(fast_sched_, gf) != GGML_STATUS_SUCCESS) {
-        std::fprintf(stderr, "[fast_decode] sched compute failed\n");
+        ggml_backend_tensor_set(hidden0,   hidden_in.data(),    0, hidden_in.size() * sizeof(float));
+        ggml_backend_tensor_set(positions, pos_vals.data(),     0, pos_vals.size() * sizeof(int32_t));
+        if (prefix_ids) {
+            ggml_backend_tensor_set(prefix_ids, prefix_tokens.data(), 0, prefix_tokens.size() * sizeof(int32_t));
+        }
+
+        if (ggml_backend_sched_graph_compute(fast_sched_, gf) != GGML_STATUS_SUCCESS) {
+            std::fprintf(stderr, "[fast_decode] sched compute failed\n");
+            ggml_backend_sched_reset(fast_sched_);
+            ggml_free(ctx0);
+            return false;
+        }
+
         ggml_backend_sched_reset(fast_sched_);
-        ggml_free(ctx0);
-        return false;
     }
 
     logits_out.resize(hparams_.codebook_size);
     ggml_backend_tensor_get(logits, logits_out.data(), 0, hparams_.codebook_size * sizeof(float));
 
-    ggml_backend_sched_reset(fast_sched_);
     ggml_free(ctx0);
     return true;
 }

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -1284,12 +1284,14 @@ bool SlowARModel::fast_decode(const std::vector<float> & hidden_in,
             ggml_free(ctx0);
             return false;
         }
-
-        ggml_backend_sched_reset(fast_sched_);
     }
 
     logits_out.resize(hparams_.codebook_size);
     ggml_backend_tensor_get(logits, logits_out.data(), 0, hparams_.codebook_size * sizeof(float));
+
+    if (!is_cpu_only) {
+        ggml_backend_sched_reset(fast_sched_);
+    }
 
     ggml_free(ctx0);
     return true;


### PR DESCRIPTION
- Implemented ggml_gallocr_t with proper lifecycle management.

- We check if we're running purely on CPU and use the cached codepath, or fallback to old behavior when any GPU backend is involved.

- This effectively eliminates redundant allocation cycles in Fast-AR decoding loop for pure CPU configs.

## Before/After PR test

**CPU:** AMD Ryzen 7 5700X3D (8C/16T, pinned to physical cores)  
**Model:** `s2-pro-q8_0.gguf` | **Backend:** CPU (`-ngl 0`) | **Allocator:** mimalloc  
**Prompt:** "hello world, how are you today?" (~204 tokens prefill)

| Metric | Without gallocr | With gallocr | Delta |
| :--- | :--- | :--- | :--- |
| **Gen Loop Avg** | 294.36 ms/frame | **274.90 ms/frame** | **-6.6%** |
| **Total Avg** | 399.09 ms/frame | **382.14 ms/frame** | **-4.2%** |
| **Gen RTF** | 7.66 | **7.27** | **-5.1%** |
| **Total RTF** | 8.59 | **8.23** | **-4.2%** |
| **Prefill** | 3675 ms | **3503 ms** | **-4.7%** |
| **Decode** | 2592 ms | **2485 ms** | **-4.1%** |
| **Max RSS** | 6351 MB | **6329 MB** | **-22 MB** |



<details>
<summary>My build script:</summary>

```bash
#!/bin/bash

# ==============================================================================
# s2.cpp CPU Build Script - Optimized for AMD Ryzen 5700X3D (Zen 3)
# ==============================================================================

# Duke nukem
# rm -rf build/

export CC=clang
export CXX=clang++

export OPT_FLAGS="-O3 -march=znver3 -flto=thin -ffast-math -fno-finite-math-only -funroll-loops -mprefer-vector-width=256"

export LINK_FLAGS="-fuse-ld=lld -flto=thin -lmimalloc"

# Configure via Ninja
cmake -S . -B build -G Ninja \
  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_C_FLAGS="$OPT_FLAGS" \
  -DCMAKE_CXX_FLAGS="$OPT_FLAGS" \
  -DCMAKE_EXE_LINKER_FLAGS="$LINK_FLAGS" \
  -DCMAKE_SHARED_LINKER_FLAGS="$LINK_FLAGS" \
  -DS2_VULKAN=OFF \
  -DS2_AUTO_APPLY_LOCAL_PATCHES=OFF \
  -DGGML_VULKAN=OFF \
  -DGGML_NATIVE=OFF \
  -DGGML_AVX2=ON \
  -DGGML_FMA=ON \
  -DGGML_F16C=ON \
  -DGGML_OPENMP=OFF \
  -DBUILD_SHARED_LIBS=OFF \
  -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
  -DGGML_LTO=OFF

# GGML_LTO / CMAKE_INTERPROCEDURAL_OPTIMIZATION:
# we are manually forcing "-flto=thin" and "-fuse-ld=lld" through our raw compilation flags, redundant.
cmake --build build --config Release --parallel

echo ""
echo "Build complete. Binary: build/s2"
echo "Remember to set at runtime:"
echo "  export GGML_CPU_ALL_CORES=0"
echo "  export GGML_CPU_STRICT=1"
echo "  export MIMALLOC_PURGE_DELAY=0"

```

</details>


<details>
<summary>My runtime setup:</summary>

```bash
export GGML_CPU_ALL_CORES=0
export GGML_CPU_STRICT=1
export MIMALLOC_PURGE_DELAY=0
export MIMALLOC_ALLOW_LARGE_OS_PAGES=1

./s2_CPU \
  -m models/s2-pro-q8_0.gguf \
  -t models/tokenizer.json \
  -v -1 \
  --threads 8 \
  --temp 0.8 \
  --top-p 0.95 \
  --voice 69 \
  --codec-context-frames 128 \
  --codec-follow-backend \
  -text "hello world, how are you today?" \
  -o output.wav
  ```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved CPU-only decoding efficiency by reusing a cached allocator across repeated inference runs.
  * Reduced decoding overhead by using an optimized CPU execution path when GPU offload is inactive.

* **Bug Fixes**
  * Improved reliability of fast decoding across CPU-only and GPU-accelerated configurations.
  * Added safer handling for allocator/scheduler allocation and graph execution failures, with earlier failure returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->