### PR TITLE
feat: mmap lazy loading and phase-gated VRAM swap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ set(S2_CORE_SOURCES
     src/s2_pipeline.cpp
     src/s2_server.cpp
     src/s2_voice.cpp
+    src/s2_mapped_file.cpp
 )
 
 function(s2_configure_target target_name)

--- a/include/s2_codec.h
+++ b/include/s2_codec.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "s2_backend.h"
+#include "s2_mapped_file.h"
 #include "ggml.h"
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
@@ -10,6 +11,8 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <unordered_set>
+#include <unordered_map>
 
 #include "s2_model.h"
 
@@ -24,10 +27,6 @@ public:
 
     bool load_shared(SlowARModel* Model, gguf_context * gguf_ctx, const std::string & gguf_path, int32_t gpu_device = -1, BackendType backend_type = BackendType::CPU);
 
-    bool read_tensor_data(const std::string & gguf_path, gguf_context * gguf_ctx);
-
-    bool refresh_host_caches();
-
     ggml_context * weights_ctx() const;
 
     bool encode(const float * audio, int32_t n_samples, int32_t n_threads,
@@ -37,6 +36,20 @@ public:
         std::vector<float> & audio_out);
 
     void clear_decode_cache();
+
+    MappedFile& mapped_file();
+
+    bool restore_weights_to_gpu();
+
+    bool free_gpu_weights();
+
+    bool is_weights_on_gpu() const;
+
+    bool refresh_host_caches_from_mmap();
+
+    bool ensure_weights_loaded();
+
+    size_t get_gpu_memory_usage_bytes() const;
 
     int32_t sample_rate()     const { return sample_rate_; }
     int32_t hop_length()      const { return hop_length_; }

--- a/include/s2_mapped_file.h
+++ b/include/s2_mapped_file.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <cstddef>
+#include <cstdint>
+
+namespace s2 {
+
+class MappedFile {
+public:
+    MappedFile() = default;
+    ~MappedFile() { close(); }
+    
+    MappedFile(const MappedFile&) = delete;
+    MappedFile& operator=(const MappedFile&) = delete;
+    
+    MappedFile(MappedFile&& other) noexcept;
+    MappedFile& operator=(MappedFile&& other) noexcept;
+
+    bool open(const std::string& path);
+    void close();
+    void drop_page_cache();
+    
+    bool is_open() const { return data_ != nullptr; }
+    const uint8_t* data() const { return static_cast<const uint8_t*>(data_); }
+    size_t size() const { return size_; }
+
+private:
+    void* data_ = nullptr;
+    size_t size_ = 0;
+    
+#ifdef _WIN32
+    void* file_handle_ = nullptr;
+    void* mapping_handle_ = nullptr;
+#else
+    int fd_ = -1;
+#endif
+};
+
+}

--- a/include/s2_model.h
+++ b/include/s2_model.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "s2_mapped_file.h"
 #include "s2_backend.h"
 #include "ggml.h"
 #include "ggml-alloc.h"
@@ -19,6 +20,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 namespace s2 {
@@ -98,8 +100,6 @@ public:
 
     bool load_shared(gguf_context * gguf_ctx, const std::string & gguf_path, int32_t gpu_device = -1, BackendType backend_type = BackendType::CPU, int32_t n_gpu_layers = -1);
 
-    bool read_tensor_data(const std::string & gguf_path, gguf_context * gguf_ctx);
-
     ggml_context * weights_ctx() { return weights_.ctx_w; }
     const std::unordered_set<ggml_tensor *> & weight_tensor_set() const { return weight_tensor_set_; }
 
@@ -108,6 +108,22 @@ public:
     void reset();
 
     void clear_kv_cache();
+
+    MappedFile& mapped_file() { return mapped_gguf_; }
+
+    bool allocate_and_load_weights();
+
+    bool restore_weights_to_gpu();
+
+    bool free_gpu_weights();
+
+    void free_compute_buffers();
+
+    void acquire_compute_resources();
+
+    size_t get_gpu_memory_usage_bytes() const;
+
+    bool is_weights_on_gpu() const { return weights_on_gpu_; }
 
 private:
     bool eval_cached(const std::vector<int32_t> & flat_tokens,
@@ -151,6 +167,16 @@ private:
     std::vector<uint8_t> fast_ctx_buf_;
 
     std::unordered_set<ggml_tensor *> weight_tensor_set_;
+
+    std::string gguf_path_;
+    size_t gguf_data_offset_ = 0;
+    std::unordered_map<ggml_tensor*, size_t> tensor_offsets_;
+    std::vector<ggml_tensor*> original_gpu_weights_;
+    std::vector<ggml_tensor*> original_cpu_weights_;
+    bool weights_on_gpu_ = false;
+    bool weights_allocated_ = false;
+
+    MappedFile mapped_gguf_;
 
 };
 

--- a/include/s2_pipeline.h
+++ b/include/s2_pipeline.h
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <string>
 #include <mutex>
+#include <thread>
 
 namespace s2 {
 
@@ -46,6 +47,9 @@ struct PipelineParams {
     std::string voice_id;
     bool save_voice = false;
     std::string voice_storage_dir = "./voices";
+    bool enable_vram_swap = true;
+    bool enable_hot_swap = false;   
+    bool is_persistent = false; 
 };
 
 class Pipeline {
@@ -108,8 +112,11 @@ private:
     Tokenizer* tokenizer_ref_ = &owned_tokenizer_;
     SlowARModel* model_ref_ = &owned_model_;
     AudioCodec* codec_ref_ = &owned_codec_;
+    std::thread pending_offload_thread_;
     mutable std::mutex synthesize_mutex_;
     bool initialized_ = false;
+    bool model_prefers_gpu_ = false;
+    bool codec_prefers_gpu_ = false;
 };
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,6 +90,8 @@ void print_uso() {
     safe_print("  --codec-auto                Benchmark codec backends and keep the fastest (default)\n");
     safe_print("  --codec-follow-backend      Force codec to follow the selected GPU backend\n");
     safe_print("  --codec-cpu                 Force codec on CPU even when model uses GPU\n");
+    safe_print("  --no-vram-swap              Disable phase-gated VRAM swapping between Slow-AR and Codec (keeps both in VRAM simultaneously instead)\n");
+    safe_print("  --hot-swap                  Aggressively evict weights and OS page cache after each server request (~100 MB RAM, ~25 MB VRAM idle)\n");
     safe_print("  --stream-file               Write output WAV through the streaming path\n");
     safe_print("  --stream-decode-stride <n>  Decode cadence in frames (0 = auto: server 4, file/offline 16)\n");
     safe_print("  --codec-context-frames <n>  Override codec decode history (lower uses less VRAM, default: auto)\n");
@@ -186,16 +188,18 @@ int main(int argc, char** argv) {
         else if (arg == "-temp" || arg == "--temp" || arg == "--temperature") { if (i+1 < argc) { try { params.gen.temperature = std::stof(argv[++i]); } catch(...) {} } }
         else if (arg == "-top-p" || arg == "--top-p")      { if (i+1 < argc) { try { params.gen.top_p       = std::stof(argv[++i]); } catch(...) {} } }
         else if (arg == "-top-k" || arg == "--top-k")      { if (i+1 < argc) { try { params.gen.top_k       = std::stoi(argv[++i]); } catch(...) {} } }
-        else if (arg == "--dynamic-normalize")     { params.normalize_dynamic = true;  }
-        else if (arg == "--no-dynamic-normalize")  { params.normalize_dynamic = false; }
-        else if (arg == "--no-trim-silence")  { params.trim_silence     = false; }
-        else if (arg == "--trim-silence")     { params.trim_silence     = true;  }
-        else if (arg == "--no-normalize")     { params.normalize_output = false; }
-        else if (arg == "--normalize")        { params.normalize_output = true;  }
-        else if (arg == "--codec-auto")       { params.codec_auto_backend = true;  params.codec_follow_backend = true;  }
-        else if (arg == "--codec-follow-backend") { params.codec_auto_backend = false; params.codec_follow_backend = true; }
-        else if (arg == "--codec-cpu")        { params.codec_auto_backend = false; params.codec_follow_backend = false; }
-        else if (arg == "--stream-file")      { use_stream_file = true; }
+        else if (arg == "--dynamic-normalize")     { params.normalize_dynamic  = true;  }
+        else if (arg == "--no-dynamic-normalize")  { params.normalize_dynamic  = false; }
+        else if (arg == "--no-trim-silence")       { params.trim_silence       = false; }
+        else if (arg == "--trim-silence")          { params.trim_silence       = true;  }
+        else if (arg == "--no-normalize")          { params.normalize_output   = false; }
+        else if (arg == "--normalize")             { params.normalize_output   = true;  }
+        else if (arg == "--codec-auto")            { params.codec_auto_backend = true;  params.codec_follow_backend = true; }
+        else if (arg == "--codec-follow-backend")  { params.codec_auto_backend = false; params.codec_follow_backend = true; }
+        else if (arg == "--codec-cpu")             { params.codec_auto_backend = false; params.codec_follow_backend = false; }
+        else if (arg == "--no-vram-swap")          { params.enable_vram_swap   = false; }
+        else if (arg == "--hot-swap")              { params.enable_hot_swap    = true; }
+        else if (arg == "--stream-file")           { use_stream_file = true; }
         else if (arg == "--stream-decode-stride") {
             if (i+1 < argc) {
                 try { params.stream_decode_stride_frames = std::stoi(argv[++i]); } catch(...) {}
@@ -309,6 +313,7 @@ int main(int argc, char** argv) {
 
     if (use_server) {
         serverParams.pipeline = params;
+        serverParams.pipeline.is_persistent = true;
         s2::Server server;
         if (!server.serve(serverParams)) {
             safe_print_error("Server initialization failed.\n");

--- a/src/s2_codec.cpp
+++ b/src/s2_codec.cpp
@@ -20,6 +20,7 @@
 #include <limits>
 #include <new>
 #include <stdexcept>
+#include <chrono>
 
 namespace s2 {
 
@@ -61,9 +62,10 @@ struct codec_decode_cache {
 };
 
 struct AudioCodec::Impl {
-    ggml_backend_t        backend   = nullptr;
-    ggml_context *        ctx_w     = nullptr;
-    ggml_backend_buffer_t model_buf = nullptr;
+    ggml_backend_t        backend     = nullptr;
+    ggml_backend_t        backend_cpu = nullptr;
+    ggml_context *        ctx_w       = nullptr;
+    ggml_backend_buffer_t model_buf   = nullptr;
     std::string tprefix;
 
     int32_t sample_rate   = 0;
@@ -103,6 +105,15 @@ struct AudioCodec::Impl {
     std::vector<vq_cache> residual_vq;
 
     codec_decode_cache decode_cache;
+    std::string gguf_path;
+    size_t gguf_data_offset = 0;
+    std::unordered_map<ggml_tensor*, size_t> tensor_offsets;
+    std::vector<ggml_tensor*> original_gpu_weights;
+    std::vector<ggml_tensor*> original_cpu_weights;
+    std::vector<ggml_tensor*> all_codec_weights;
+    bool weights_on_gpu = false;
+    MappedFile mapped_gguf_;
+    bool weights_allocated_ = false;
 };
 
 static const char * backend_type_name(BackendType backend_type) {
@@ -113,6 +124,53 @@ static const char * backend_type_name(BackendType backend_type) {
         case BackendType::Metal:  return "Metal";
     }
     return "Unknown";
+}
+
+static bool allocate_codec_buffers(ggml_backend_t backend,
+                                   const std::vector<ggml_tensor *> & tensors,
+                                   ggml_backend_buffer_t & out_buffer,
+                                   size_t & total_bytes,
+                                   std::string & error_message) {
+    out_buffer = nullptr;
+    total_bytes = 0;
+    error_message.clear();
+    if (backend == nullptr || tensors.empty()) return true;
+
+    const ggml_backend_buffer_type_t buft = ggml_backend_get_default_buffer_type(backend);
+    const size_t alignment = ggml_backend_buft_get_alignment(buft);
+    
+    for (ggml_tensor * tensor : tensors) {
+        const size_t alloc_size = ggml_backend_buft_get_alloc_size(buft, tensor);
+        const size_t rem = total_bytes % alignment;
+        if (rem != 0) total_bytes += (alignment - rem);
+        total_bytes += alloc_size;
+    }
+
+    if (total_bytes == 0) return true;
+
+    out_buffer = ggml_backend_buft_alloc_buffer(buft, total_bytes);
+    if (!out_buffer) {
+        error_message = "failed to allocate codec buffer of size " + std::to_string(total_bytes);
+        return false;
+    }
+
+    ggml_backend_buffer_set_usage(out_buffer, GGML_BACKEND_BUFFER_USAGE_WEIGHTS);
+    
+    char * base_ptr = static_cast<char *>(ggml_backend_buffer_get_base(out_buffer));
+    size_t current_offset = 0;
+    
+    for (ggml_tensor * tensor : tensors) {
+        const size_t alloc_size = ggml_backend_buft_get_alloc_size(buft, tensor);
+        const size_t rem = current_offset % alignment;
+        if (rem != 0) current_offset += (alignment - rem);
+        
+        tensor->data = base_ptr + current_offset;
+        tensor->buffer = out_buffer;
+        
+        current_offset += alloc_size;
+    }
+    
+    return true;
 }
 
 static void reset_decode_cache(codec_decode_cache & cache, bool preserve_failed_n_frames = true) {
@@ -873,8 +931,47 @@ bool AudioCodec::load_shared(SlowARModel* Model, gguf_context * shared_gguf_ctx,
             streaming_history_frames_ = 160;
         }
 
-        impl_->model_buf = ggml_backend_alloc_ctx_tensors(impl_->ctx_w, impl_->backend);
-        if (!impl_->model_buf) throw std::runtime_error("ggml_backend_alloc_ctx_tensors() failed");
+        if (!impl_->backend_cpu) {
+            impl_->backend_cpu = ggml_backend_cpu_init();
+        }
+
+        impl_->gguf_path = gguf_path;
+        impl_->gguf_data_offset = gguf_get_data_offset(shared_gguf_ctx);
+
+        const int64_t n_tensors = gguf_get_n_tensors(shared_gguf_ctx);
+        const auto & model_weights = Model ? Model->weight_tensor_set() : std::unordered_set<ggml_tensor*>();
+
+        impl_->all_codec_weights.clear();
+        impl_->tensor_offsets.clear();
+        impl_->original_gpu_weights.clear();
+        impl_->original_cpu_weights.clear();
+
+        for (int64_t ti = 0; ti < n_tensors; ++ti) {
+            const char * tname = gguf_get_tensor_name(shared_gguf_ctx, ti);
+            ggml_tensor * t = ggml_get_tensor(impl_->ctx_w, tname);
+            if (!t) continue;
+
+            // Skip tensors that belong to the SlowAR Model
+            if (Model && model_weights.find(t) != model_weights.end()) continue;
+
+            impl_->all_codec_weights.push_back(t);
+            impl_->tensor_offsets[t] = gguf_get_tensor_offset(shared_gguf_ctx, ti);
+
+            if (!ggml_backend_is_cpu(impl_->backend)) {
+                impl_->original_gpu_weights.push_back(t);
+            } else {
+                impl_->original_cpu_weights.push_back(t);
+            }
+        }
+
+        impl_->weights_on_gpu = false;
+
+        impl_->mapped_gguf_.open(gguf_path);
+        if (!impl_->mapped_gguf_.is_open()) {
+            throw std::runtime_error("Failed to mmap " + gguf_path);
+        }
+
+        impl_->weights_allocated_ = false;
 
         impl_->semantic_vq = vq_cache();
         impl_->residual_vq.clear();
@@ -887,89 +984,23 @@ bool AudioCodec::load_shared(SlowARModel* Model, gguf_context * shared_gguf_ctx,
     return true;
 }
 
-bool AudioCodec::refresh_host_caches() {
-    if (!impl_ || !impl_->ctx_w) {
-        return false;
-    }
-
-    try {
-        impl_->semantic_vq = load_vq_cache(impl_->ctx_w,
-            impl_->tprefix + "quantizer.semantic_quantizer.quantizers.0",
-            impl_->quantizer_input_dim, impl_->quantizer_codebook_dim,
-            impl_->quantizer_semantic_codebook_size);
-
-        impl_->residual_vq.clear();
-        impl_->residual_vq.reserve(impl_->quantizer_residual_codebooks);
-        for (int32_t i = 0; i < impl_->quantizer_residual_codebooks; ++i) {
-            impl_->residual_vq.push_back(load_vq_cache(impl_->ctx_w,
-                impl_->tprefix + "quantizer.quantizer.quantizers." + std::to_string(i),
-                impl_->quantizer_input_dim, impl_->quantizer_codebook_dim,
-                impl_->quantizer_residual_codebook_size));
-        }
-    } catch (const std::exception & e) {
-        std::cerr << "[Codec] Failed to refresh VQ caches: " << e.what() << std::endl;
-        impl_->semantic_vq = vq_cache();
-        impl_->residual_vq.clear();
-        return false;
-    }
-
-    return true;
-}
-
-bool AudioCodec::read_tensor_data(const std::string & gguf_path, gguf_context * gguf_ctx) {
-    if (!impl_ || !impl_->ctx_w) return false;
-
-    const size_t data_offset = gguf_get_data_offset(gguf_ctx);
-    const int64_t n_tensors  = gguf_get_n_tensors(gguf_ctx);
-
-    std::FILE * f = std::fopen(gguf_path.c_str(), "rb");
-    if (!f) {
-        std::cerr << "[Codec] Failed to reopen " << gguf_path << " for data loading." << std::endl;
-        return false;
-    }
-    for (int64_t ti = 0; ti < n_tensors; ++ti) {
-        const char * name = gguf_get_tensor_name(gguf_ctx, ti);
-        ggml_tensor * t = ggml_get_tensor(impl_->ctx_w, name);
-        if (!t) continue;
-        const size_t off   = data_offset + gguf_get_tensor_offset(gguf_ctx, ti);
-        const size_t nbytes = ggml_nbytes(t);
-        std::vector<uint8_t> tmp(nbytes);
-#ifdef _WIN32
-        _fseeki64(f, (int64_t)off, SEEK_SET);
-#else
-        fseeko(f, (off_t)off, SEEK_SET);
-#endif
-        if (std::fread(tmp.data(), 1, nbytes, f) != nbytes) {
-            std::fclose(f);
-            std::cerr << "[Codec] Failed to read tensor: " << name << std::endl;
-            return false;
-        }
-        ggml_backend_tensor_set(t, tmp.data(), 0, nbytes);
-    }
-    std::fclose(f);
-    return refresh_host_caches();
-}
-
 bool AudioCodec::load(const std::string & gguf_path, int32_t gpu_device, BackendType backend_type) {
-
     struct gguf_init_params params = { true, nullptr };
     gguf_context * ctx_gguf = gguf_init_from_file(gguf_path.c_str(), params);
     if (!ctx_gguf) {
         std::cerr << "[Codec] Failed to open " << gguf_path << std::endl;
         return false;
     }
-
     if (!load_shared(nullptr, ctx_gguf, gguf_path, gpu_device, backend_type)) {
         gguf_free(ctx_gguf);
         return false;
     }
-
-    if (!read_tensor_data(gguf_path, ctx_gguf)) {
-        gguf_free(ctx_gguf);
+    gguf_free(ctx_gguf);
+    
+    if (!refresh_host_caches_from_mmap()) {
+        std::cerr << "[Codec] Failed to refresh VQ caches from mmap." << std::endl;
         return false;
     }
-
-    gguf_free(ctx_gguf);
     return true;
 }
 
@@ -979,6 +1010,8 @@ ggml_context * AudioCodec::weights_ctx() const {
 
 bool AudioCodec::encode(const float * audio, int32_t n_samples, int32_t n_threads,
                          std::vector<int32_t> & codes_out, int32_t & n_frames_out) {
+
+    if (!ensure_weights_loaded()) return false;
 
     const int32_t frame_length = (impl_->frame_length > 0) ? impl_->frame_length : 512;
     const int32_t padded = ((n_samples + frame_length - 1) / frame_length) * frame_length;
@@ -1298,6 +1331,7 @@ bool AudioCodec::decode(const int32_t * codes, int32_t n_frames, int32_t n_threa
                          std::vector<float> & audio_out) {
     if (n_frames <= 0) return false;
     if (!impl_ || !impl_->backend) return false;
+    if (!ensure_weights_loaded()) return false;
 
     if (!ggml_backend_is_cpu(impl_->backend) &&
         run_cached_decode_graph(*impl_, codes, n_frames, n_threads, audio_out)) {
@@ -1443,5 +1477,113 @@ bool AudioCodec::decode(const int32_t * codes, int32_t n_frames, int32_t n_threa
     
     return true;
 }
+
+bool AudioCodec::is_weights_on_gpu() const {
+    return impl_ ? impl_->weights_on_gpu : false;
+}
+
+bool AudioCodec::free_gpu_weights() {
+    if (!impl_ || !impl_->weights_on_gpu) return true;
+    
+    S2_LOG_INFO_STREAM("[Codec] >>> FREEING Audio Codec GPU weights..." << std::endl);
+    const auto t0 = std::chrono::steady_clock::now();
+    
+    ggml_backend_synchronize(impl_->backend);
+
+    if (impl_->model_buf) {
+        ggml_backend_buffer_free(impl_->model_buf);
+        impl_->model_buf = nullptr;
+    }
+    
+    for (ggml_tensor * t : impl_->all_codec_weights) {
+        if (t) { t->data = nullptr; t->buffer = nullptr; }
+    }
+    
+    impl_->weights_allocated_ = false;
+    impl_->weights_on_gpu = false;
+    
+    const auto t1 = std::chrono::steady_clock::now();
+    const double free_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    S2_LOG_INFO_STREAM("[Codec] <<< Audio Codec GPU weights FREED in " << free_ms << " ms" << std::endl);
+    return true;
+}
+
+bool AudioCodec::restore_weights_to_gpu() {
+    if (!impl_ || impl_->weights_on_gpu || impl_->original_gpu_weights.empty()) return true;
+    S2_LOG_INFO_STREAM("[Codec] >>> RESTORING Audio Codec weights from mmap to GPU..." << std::endl);
+    const auto t0 = std::chrono::steady_clock::now();
+    impl_->weights_allocated_ = false;
+    if (!ensure_weights_loaded()) return false;
+    const auto t1 = std::chrono::steady_clock::now();
+    const double restore_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    S2_LOG_INFO_STREAM("[Codec] <<< Audio Codec weights RESTORED in " << restore_ms << " ms" << std::endl);
+    return true;
+}
+
+size_t AudioCodec::get_gpu_memory_usage_bytes() const {
+    if (!impl_ || !impl_->model_buf || !impl_->weights_on_gpu) return 0;
+    return ggml_backend_buffer_get_size(impl_->model_buf);
+}
+
+bool AudioCodec::refresh_host_caches_from_mmap() {
+    if (!impl_ || !impl_->mapped_gguf_.is_open()) return false;
+    auto read_f32 = [&](const std::string& name) -> std::vector<float> {
+        ggml_tensor* t = ggml_get_tensor(impl_->ctx_w, name.c_str());
+        if (!t) throw std::runtime_error("missing vq tensor: " + name);
+        auto it = impl_->tensor_offsets.find(t);
+        if (it == impl_->tensor_offsets.end()) throw std::runtime_error("missing offset");
+        const size_t n = ggml_nelements(t);
+        std::vector<float> out(n);
+        const uint8_t* src = impl_->mapped_gguf_.data() + impl_->gguf_data_offset + it->second;
+        if (t->type == GGML_TYPE_F32) std::memcpy(out.data(), src, n * sizeof(float));
+        else if (t->type == GGML_TYPE_F16) {
+            const ggml_fp16_t* tmp = reinterpret_cast<const ggml_fp16_t*>(src);
+            for (size_t i = 0; i < n; ++i) out[i] = ggml_fp16_to_fp32(tmp[i]);
+        }
+        return out;
+    };
+    try {
+        auto load_vq = [&](const std::string& prefix, int32_t in_dim, int32_t cb_dim, int32_t cb_size) -> vq_cache {
+            vq_cache vq; vq.input_dim = in_dim; vq.codebook_dim = cb_dim; vq.codebook_size = cb_size;
+            vq.in_proj_weight = read_f32(prefix + ".in_proj.weight"); vq.in_proj_bias = read_f32(prefix + ".in_proj.bias");
+            vq.out_proj_weight = read_f32(prefix + ".out_proj.weight"); vq.out_proj_bias = read_f32(prefix + ".out_proj.bias");
+            vq.codebook = read_f32(prefix + ".codebook.weight");
+            vq.codebook_norm.resize(vq.codebook.size());
+            for (int32_t c = 0; c < cb_size; ++c) {
+                float norm = 0.0f; const size_t base = c * cb_dim;
+                for (int32_t d = 0; d < cb_dim; ++d) norm += vq.codebook[base+d] * vq.codebook[base+d];
+                norm = std::sqrt(std::max(norm, 1e-12f));
+                for (int32_t d = 0; d < cb_dim; ++d) vq.codebook_norm[base+d] = vq.codebook[base+d] / norm;
+            }
+            return vq;
+        };
+        impl_->semantic_vq = load_vq(impl_->tprefix + "quantizer.semantic_quantizer.quantizers.0", impl_->quantizer_input_dim, impl_->quantizer_codebook_dim, impl_->quantizer_semantic_codebook_size);
+        impl_->residual_vq.clear(); impl_->residual_vq.reserve(impl_->quantizer_residual_codebooks);
+        for (int32_t i = 0; i < impl_->quantizer_residual_codebooks; ++i)
+            impl_->residual_vq.push_back(load_vq(impl_->tprefix + "quantizer.quantizer.quantizers." + std::to_string(i), impl_->quantizer_input_dim, impl_->quantizer_codebook_dim, impl_->quantizer_residual_codebook_size));
+    } catch (const std::exception& e) { std::cerr << "[Codec] VQ mmap load failed: " << e.what() << std::endl; return false; }
+    return true;
+}
+
+bool AudioCodec::ensure_weights_loaded() {
+    if (!impl_ || impl_->weights_allocated_) return true;
+    if (!impl_->mapped_gguf_.is_open()) return false;
+    S2_LOG_INFO_STREAM("[Codec] >>> Allocating and loading Audio Codec weights on demand..." << std::endl);
+    size_t b = 0; std::string e;
+    if (!allocate_codec_buffers(impl_->backend, impl_->all_codec_weights, impl_->model_buf, b, e)) {
+        std::cerr << "[Codec] Alloc failed: " << e << std::endl; return false;
+    }
+    const uint8_t* base = impl_->mapped_gguf_.data();
+    for (ggml_tensor * t : impl_->all_codec_weights) {
+        auto it = impl_->tensor_offsets.find(t);
+        if (it != impl_->tensor_offsets.end())
+            ggml_backend_tensor_set(t, base + impl_->gguf_data_offset + it->second, 0, ggml_nbytes(t));
+    }
+    impl_->weights_allocated_ = true;
+    impl_->weights_on_gpu = !ggml_backend_is_cpu(impl_->backend);
+    return true;
+}
+
+MappedFile& AudioCodec::mapped_file() { return impl_->mapped_gguf_; }
 
 }

--- a/src/s2_mapped_file.cpp
+++ b/src/s2_mapped_file.cpp
@@ -16,8 +16,11 @@ bool MappedFile::open(const std::string& path) {
     close();
     
 #ifdef _WIN32
+    // GGUF is mostly sequential
     HANDLE fh = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, 
-                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+                            nullptr, OPEN_EXISTING,
+                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
+                            nullptr);
     if (fh == INVALID_HANDLE_VALUE) {
         return false;
     }
@@ -75,7 +78,15 @@ bool MappedFile::open(const std::string& path) {
         return false; 
     }
     
-    ::madvise(addr, size_, MADV_RANDOM);
+    // GGUF is mostly sequential
+    ::madvise(addr, size_, MADV_SEQUENTIAL);
+
+#ifdef __linux__
+    // Huge pages reduce TLB pressure during multi-GB weight loads.
+    ::madvise(addr, size_, MADV_HUGEPAGE);
+    // Exclude from core dumps so we don't write entire model to disk in a crash.
+    ::madvise(addr, size_, MADV_DONTDUMP);
+#endif
     
     data_ = addr; 
     fd_ = fd;

--- a/src/s2_mapped_file.cpp
+++ b/src/s2_mapped_file.cpp
@@ -1,0 +1,173 @@
+#include "../include/s2_mapped_file.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+namespace s2 {
+
+bool MappedFile::open(const std::string& path) {
+    close();
+    
+#ifdef _WIN32
+    HANDLE fh = CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ, 
+                            nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (fh == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+    
+    LARGE_INTEGER file_size;
+    if (!GetFileSizeEx(fh, &file_size)) { 
+        CloseHandle(fh); 
+        return false; 
+    }
+    size_ = static_cast<size_t>(file_size.QuadPart);
+    
+    if (size_ == 0) { 
+        CloseHandle(fh); 
+        return true;
+    }
+    
+    HANDLE mh = CreateFileMappingA(fh, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    if (!mh) { 
+        CloseHandle(fh); 
+        return false; 
+    }
+    
+    void* addr = MapViewOfFile(mh, FILE_MAP_READ, 0, 0, size_);
+    if (!addr) { 
+        CloseHandle(mh); 
+        CloseHandle(fh); 
+        return false; 
+    }
+    
+    data_ = addr; 
+    file_handle_ = static_cast<void*>(fh); 
+    mapping_handle_ = static_cast<void*>(mh);
+    
+#else
+    int fd = ::open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        return false;
+    }
+    
+    struct stat st;
+    if (fstat(fd, &st) < 0) { 
+        ::close(fd); 
+        return false; 
+    }
+    size_ = static_cast<size_t>(st.st_size);
+    
+    if (size_ == 0) { 
+        ::close(fd); 
+        return true;
+    }
+    
+    void* addr = ::mmap(nullptr, size_, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (addr == MAP_FAILED) { 
+        ::close(fd); 
+        return false; 
+    }
+    
+    ::madvise(addr, size_, MADV_RANDOM);
+    
+    data_ = addr; 
+    fd_ = fd;
+#endif
+
+    return true;
+}
+
+void MappedFile::close() {
+#ifdef _WIN32
+    if (data_) {
+        UnmapViewOfFile(data_);
+        data_ = nullptr;
+    }
+    if (mapping_handle_) {
+        CloseHandle(static_cast<HANDLE>(mapping_handle_));
+        mapping_handle_ = nullptr;
+    }
+    if (file_handle_) {
+        CloseHandle(static_cast<HANDLE>(file_handle_));
+        file_handle_ = nullptr;
+    }
+#else
+    if (data_ && data_ != MAP_FAILED) {
+        ::munmap(data_, size_);
+        data_ = nullptr;
+    }
+    if (fd_ >= 0) {
+        ::close(fd_);
+        fd_ = -1;
+    }
+#endif
+    size_ = 0;
+}
+
+MappedFile::MappedFile(MappedFile&& other) noexcept {
+#ifdef _WIN32
+    data_ = other.data_; 
+    other.data_ = nullptr; 
+    size_ = other.size_; 
+    other.size_ = 0;
+    file_handle_ = other.file_handle_; 
+    other.file_handle_ = nullptr;
+    mapping_handle_ = other.mapping_handle_; 
+    other.mapping_handle_ = nullptr;
+#else
+    data_ = other.data_; 
+    other.data_ = nullptr; 
+    size_ = other.size_; 
+    other.size_ = 0; 
+    fd_ = other.fd_; 
+    other.fd_ = -1;
+#endif
+}
+
+MappedFile& MappedFile::operator=(MappedFile&& other) noexcept {
+    if (this != &other) { 
+        close();
+#ifdef _WIN32
+        data_ = other.data_; 
+        other.data_ = nullptr; 
+        size_ = other.size_; 
+        other.size_ = 0;
+        file_handle_ = other.file_handle_; 
+        other.file_handle_ = nullptr;
+        mapping_handle_ = other.mapping_handle_; 
+        other.mapping_handle_ = nullptr;
+#else
+        data_ = other.data_; 
+        other.data_ = nullptr; 
+        size_ = other.size_; 
+        other.size_ = 0; 
+        fd_ = other.fd_; 
+        other.fd_ = -1;
+#endif
+    }
+    return *this;
+}
+
+void MappedFile::drop_page_cache() {
+#if defined(__linux__) || defined(__APPLE__)
+    if (data_ && data_ != MAP_FAILED && size_ > 0) {
+        ::madvise(data_, size_, MADV_DONTNEED);
+    }
+    if (fd_ >= 0) {
+        ::posix_fadvise(fd_, 0, 0, POSIX_FADV_DONTNEED);
+    }
+#elif defined(_WIN32)
+    if (data_ && size_ > 0) {
+        ::VirtualUnlock(data_, size_);
+    }
+#endif
+}
+
+}

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -1,5 +1,6 @@
 #include "../include/s2_model.h"
 #include "../include/s2_log.h"
+#include "../include/s2_mapped_file.h"
 #include "s2_ggml_utils.h"
 #include <iostream>
 #include <vector>
@@ -217,6 +218,8 @@ bool SlowARModel::load_shared(gguf_context * ctx_gguf, const std::string & gguf_
     }
 
     gguf_free(local_gguf);
+    gguf_path_ = gguf_path;
+    gguf_data_offset_ = gguf_get_data_offset(ctx_gguf);
 
     S2_LOG_INFO_STREAM("[Model] Reading metadata from " << gguf_path << std::endl);
 
@@ -478,6 +481,15 @@ bool SlowARModel::load_shared(gguf_context * ctx_gguf, const std::string & gguf_
 
     weight_tensor_set_.insert(weight_tensors.begin(), weight_tensors.end());
 
+    const int64_t n_tensors_gguf = gguf_get_n_tensors(ctx_gguf);
+    for (int64_t ti = 0; ti < n_tensors_gguf; ++ti) {
+        const char * tname = gguf_get_tensor_name(ctx_gguf, ti);
+        ggml_tensor * t = ggml_get_tensor(weights_.ctx_w, tname);
+        if (t && weight_tensor_set_.find(t) != weight_tensor_set_.end()) {
+            tensor_offsets_[t] = gguf_get_tensor_offset(ctx_gguf, ti);
+        }
+    }
+
     const bool full_model_offload =
         backend_gpu_ != nullptr &&
         backend_type != BackendType::CUDA &&
@@ -521,196 +533,39 @@ bool SlowARModel::load_shared(gguf_context * ctx_gguf, const std::string & gguf_
         }
     }
 
-    std::vector<ggml_backend_buffer_t> gpu_buffers;
-    std::vector<ggml_backend_buffer_t> cpu_buffers;
+    original_gpu_weights_ = gpu_weight_tensors;
+    original_cpu_weights_ = cpu_weight_tensors;
 
-    if (!gpu_weight_tensors.empty() && backend_gpu_) {
-        size_t gpu_bytes = 0;
-        size_t gpu_max_buffer = 0;
-        std::string gpu_alloc_error;
-        if (!allocate_weight_buffers(
-                backend_gpu_,
-                gpu_weight_tensors,
-                gpu_buffers,
-                gpu_bytes,
-                gpu_max_buffer,
-                gpu_alloc_error)) {
-            const double requested_mb = gpu_bytes / (1024.0 * 1024.0);
-            const double max_chunk_mb =
-                gpu_max_buffer == static_cast<size_t>(-1)
-                    ? 0.0
-                    : gpu_max_buffer / (1024.0 * 1024.0);
-            std::cerr << "[Model] GPU weight buffer allocation failed." << std::endl;
-            std::cerr << "[Model] Requested GPU memory: " << requested_mb << " MB for "
-                      << gpu_weight_tensors.size() << " tensors (" << n_gpu_layers_
-                      << " layers)" << std::endl;
-            if (gpu_max_buffer != static_cast<size_t>(-1)) {
-                std::cerr << "[Model] Backend max buffer size: " << max_chunk_mb
-                          << " MB per allocation." << std::endl;
-            }
-            if (!gpu_alloc_error.empty()) {
-                std::cerr << "[Model] " << gpu_alloc_error << std::endl;
-            }
-            std::cerr << "[Model] Suggest using a lower --gpu-layers value (e.g., --gpu-layers "
-                      << std::max(1, n_gpu_layers_ / 2) << ")" << std::endl;
-            return false;
-        }
-    }
-
-    if (!cpu_weight_tensors.empty()) {
-        size_t cpu_bytes = 0;
-        size_t cpu_max_buffer = 0;
-        std::string cpu_alloc_error;
-        if (!allocate_weight_buffers(
-                backend_cpu_,
-                cpu_weight_tensors,
-                cpu_buffers,
-                cpu_bytes,
-                cpu_max_buffer,
-                cpu_alloc_error)) {
-            free_backend_buffers(gpu_buffers);
-            std::cerr << "[Model] Failed to allocate CPU weight buffer." << std::endl;
-            if (!cpu_alloc_error.empty()) {
-                std::cerr << "[Model] " << cpu_alloc_error << std::endl;
-            }
-            return false;
-        }
-    }
-
-    weights_.model_bufs_gpu = std::move(gpu_buffers);
-    weights_.model_bufs_cpu = std::move(cpu_buffers);
-
-    {
-        ggml_backend_t backends[2];
-        int n_backends;
-        if (backend_gpu_) {
-            backends[0] = backend_gpu_;
-            backends[1] = backend_cpu_;
-            n_backends = 2;
-        } else {
-            backends[0] = backend_cpu_;
-            n_backends = 1;
-        }
-
-        sched_ = ggml_backend_sched_new(backends, NULL, n_backends, 32768, false, true);
-        if (!sched_) {
-            std::cerr << "[Model] Failed to create Slow-AR scheduler." << std::endl;
-            return false;
-        }
-
-        if (hparams_.has_fast_decoder) {
-            fast_sched_ = ggml_backend_sched_new(backends, NULL, n_backends, 16384, false, true);
-            if (!fast_sched_) {
-                std::cerr << "[Model] Failed to create Fast-AR scheduler." << std::endl;
-                return false;
-            }
-        }
-    }
-
-    if (n_gpu_layers_ > 0 && backend_gpu_) {
-        const int32_t first_cpu_layer = n_gpu_layers_;
-        const int32_t last_gpu_layer = n_gpu_layers_ - 1;
-        if (first_cpu_layer < hparams_.block_count) {
-            S2_LOG_INFO_STREAM("[Model] Layers 0-" << last_gpu_layer << " on "
-                      << ggml_backend_name(backend_gpu_)
-                      << ", " << first_cpu_layer << "-" << (hparams_.block_count - 1) << " on CPU"
-                      << std::endl);
-        } else {
-            S2_LOG_INFO_STREAM("[Model] Layers 0-" << (hparams_.block_count - 1) << " on "
-                      << ggml_backend_name(backend_gpu_) << " (all)" << std::endl);
-        }
-    } else {
-        S2_LOG_INFO_STREAM("[Model] All " << hparams_.block_count << " layers on CPU" << std::endl);
-    }
-
-    const size_t gpu_weight_bytes = total_backend_buffer_bytes(weights_.model_bufs_gpu);
-    if (!weights_.model_bufs_gpu.empty()) {
-        S2_LOG_INFO_STREAM("[Model] GPU weight buffers: " << weights_.model_bufs_gpu.size()
-                  << " chunk(s), " << (gpu_weight_bytes / 1024.0 / 1024.0)
-                  << " MB total" << std::endl);
-    }
-    const size_t cpu_weight_bytes = total_backend_buffer_bytes(weights_.model_bufs_cpu);
-    if (!weights_.model_bufs_cpu.empty()) {
-        S2_LOG_INFO_STREAM("[Model] CPU weight buffers: " << weights_.model_bufs_cpu.size()
-                  << " chunk(s), " << (cpu_weight_bytes / 1024.0 / 1024.0)
-                  << " MB total" << std::endl);
-    }
-    const size_t total_bytes = gpu_weight_bytes + cpu_weight_bytes;
-    S2_LOG_INFO_STREAM("[Model] Total model size: "
-              << (total_bytes / 1024.0 / 1024.0) << " MB" << std::endl);
-
-    S2_LOG_INFO_STREAM("[Model] KV cache: " << (n_gpu_layers_ > 0 && backend_gpu_ ? "GPU" : "CPU")
-              << ", n_gpu_layers=" << n_gpu_layers_ << std::endl);
-
-    if (backend_type == BackendType::CUDA &&
-        backend_gpu_ &&
-        ggml_is_quantized(weights_.embeddings->type)) {
-        S2_LOG_INFO_STREAM("[Model] Keeping quantized embedding tables on CPU for CUDA stability."
-                  << std::endl);
-    }
-
-    return true;
-}
-
-bool SlowARModel::read_tensor_data(const std::string & gguf_path, gguf_context * ctx_gguf) {
-    const size_t data_offset = gguf_get_data_offset(ctx_gguf);
-    const int64_t n_tensors  = gguf_get_n_tensors(ctx_gguf);
-
-    std::FILE * f = std::fopen(gguf_path.c_str(), "rb");
-    if (!f) {
-        std::cerr << "[Model] Cannot reopen " << gguf_path << " for data loading." << std::endl;
+    mapped_gguf_.open(gguf_path);
+    if (!mapped_gguf_.is_open()) {
+        std::cerr << "[Model] Failed to mmap " << gguf_path << std::endl;
         return false;
     }
-    std::vector<uint8_t> tmp;
-    for (int64_t ti = 0; ti < n_tensors; ++ti) {
-        const char * tname = gguf_get_tensor_name(ctx_gguf, ti);
-        ggml_tensor * t = ggml_get_tensor(weights_.ctx_w, tname);
 
-        if (!t || weight_tensor_set_.find(t) == weight_tensor_set_.end()) continue;
+    weights_allocated_ = false;
+    weights_on_gpu_ = false;
+    
 
-        const size_t toff  = data_offset + gguf_get_tensor_offset(ctx_gguf, ti);
-        const size_t tsize = ggml_nbytes(t);
-        if (tmp.size() < tsize) tmp.resize(tsize);
-#ifdef _WIN32
-        _fseeki64(f, (int64_t)toff, SEEK_SET);
-#else
-        fseeko(f, (off_t)toff, SEEK_SET);
-#endif
-        if (std::fread(tmp.data(), 1, tsize, f) != tsize) {
-            std::cerr << "[Model] Failed to read tensor: " << tname << std::endl;
-            std::fclose(f);
-            return false;
-        }
-        ggml_backend_tensor_set(t, tmp.data(), 0, tsize);
-    }
-    tmp.clear();
-    tmp.shrink_to_fit();
-    std::fclose(f);
-
-    S2_LOG_INFO_STREAM("[Model] Weights loaded. Total tensors: " << n_tensors << std::endl);
     return true;
 }
 
 bool SlowARModel::load(const std::string & gguf_path, int32_t gpu_device, BackendType backend_type, int32_t n_gpu_layers) {
-
     struct gguf_init_params params = { true, nullptr };
     gguf_context * ctx_gguf = gguf_init_from_file(gguf_path.c_str(), params);
     if (!ctx_gguf) {
         std::cerr << "[Model] Failed to load GGUF from " << gguf_path << std::endl;
         return false;
     }
-
     if (!load_shared(ctx_gguf, gguf_path, gpu_device, backend_type, n_gpu_layers)) {
         gguf_free(ctx_gguf);
         return false;
     }
-
-    if (!read_tensor_data(gguf_path, ctx_gguf)) {
-        gguf_free(ctx_gguf);
+    gguf_free(ctx_gguf);
+    
+    if (!allocate_and_load_weights()) {
+        std::cerr << "[Model] Failed to allocate and load weights from mmap." << std::endl;
         return false;
     }
-
-    gguf_free(ctx_gguf);
     return true;
 }
 
@@ -1251,6 +1106,122 @@ bool SlowARModel::fast_decode(const std::vector<float> & hidden_in,
 
     ggml_backend_sched_reset(fast_sched_);
     ggml_free(ctx0);
+    return true;
+}
+
+bool SlowARModel::restore_weights_to_gpu() {
+    if (!backend_gpu_ || weights_on_gpu_) return true;
+    S2_LOG_INFO_STREAM("[Model] >>> RESTORING Slow-AR weights from mmap to GPU..." << std::endl);
+    const auto t0 = std::chrono::steady_clock::now();
+    weights_allocated_ = false;
+    if (!allocate_and_load_weights()) return false;
+    const auto t1 = std::chrono::steady_clock::now();
+    const double restore_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    S2_LOG_INFO_STREAM("[Model] <<< Slow-AR weights RESTORED in " << restore_ms << " ms" << std::endl);
+    return true;
+}
+
+bool SlowARModel::free_gpu_weights() {
+    if (!backend_gpu_ || !weights_on_gpu_) return true;
+    
+    S2_LOG_INFO_STREAM("[Model] >>> FREEING Slow-AR GPU weights" << std::endl);
+    const auto t0 = std::chrono::steady_clock::now();
+    
+    ggml_backend_synchronize(backend_gpu_);
+
+    free_backend_buffers(weights_.model_bufs_gpu);
+    weights_.model_bufs_gpu.clear();
+    
+    for (ggml_tensor * t : original_gpu_weights_) {
+        if (t) { t->data = nullptr; t->buffer = nullptr; }
+    }
+    
+    weights_allocated_ = false;
+    weights_on_gpu_ = false;
+    const auto t1 = std::chrono::steady_clock::now();
+    const double free_ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    S2_LOG_INFO_STREAM("[Model] <<< Slow-AR GPU weights FREED in " << free_ms << " ms" << std::endl);
+    return true;
+}
+
+void SlowARModel::free_compute_buffers() {
+    if (backend_gpu_) ggml_backend_synchronize(backend_gpu_);
+    clear_kv_cache();
+    if (sched_) {
+        ggml_backend_sched_free(sched_);
+        sched_ = nullptr;
+    }
+    if (fast_sched_) {
+        ggml_backend_sched_free(fast_sched_);
+        fast_sched_ = nullptr;
+    }
+}
+
+void SlowARModel::acquire_compute_resources() {
+    if (sched_) return;
+    
+    ggml_backend_t backends[2];
+    int n_backends;
+    if (backend_gpu_) {
+        backends[0] = backend_gpu_;
+        backends[1] = backend_cpu_;
+        n_backends = 2;
+    } else {
+        backends[0] = backend_cpu_;
+        n_backends = 1;
+    }
+    
+    sched_ = ggml_backend_sched_new(backends, NULL, n_backends, 32768, false, true);
+    if (hparams_.has_fast_decoder) {
+        fast_sched_ = ggml_backend_sched_new(backends, NULL, n_backends, 16384, false, true);
+    }
+}
+
+size_t SlowARModel::get_gpu_memory_usage_bytes() const {
+    size_t total = 0;
+    
+    for (const auto & buf : weights_.model_bufs_gpu) {
+        if (buf) total += ggml_backend_buffer_get_size(buf);
+    }
+    
+    if (kv_buf_) {
+        total += ggml_backend_buffer_get_size(kv_buf_);
+    }
+    
+    return total;
+}
+
+bool SlowARModel::allocate_and_load_weights() {
+    if (weights_allocated_) return true;
+    if (!mapped_gguf_.is_open()) return false;
+
+    size_t b, m; std::string e;
+    if (!original_gpu_weights_.empty() && backend_gpu_) {
+        if (!allocate_weight_buffers(backend_gpu_, original_gpu_weights_, weights_.model_bufs_gpu, b, m, e)) {
+            std::cerr << "[Model] GPU alloc failed: " << e << std::endl; return false;
+        }
+    }
+    if (!original_cpu_weights_.empty()) {
+        if (!allocate_weight_buffers(backend_cpu_, original_cpu_weights_, weights_.model_bufs_cpu, b, m, e)) {
+            std::cerr << "[Model] CPU alloc failed: " << e << std::endl; return false;
+        }
+    }
+
+    const uint8_t* base = mapped_gguf_.data();
+    for (ggml_tensor * t : original_gpu_weights_) {
+        auto it = tensor_offsets_.find(t);
+        if (it != tensor_offsets_.end())
+            ggml_backend_tensor_set(t, base + gguf_data_offset_ + it->second, 0, ggml_nbytes(t));
+    }
+    for (ggml_tensor * t : original_cpu_weights_) {
+        auto it = tensor_offsets_.find(t);
+        if (it != tensor_offsets_.end())
+            ggml_backend_tensor_set(t, base + gguf_data_offset_ + it->second, 0, ggml_nbytes(t));
+    }
+
+    weights_allocated_ = true;
+    weights_on_gpu_ = !original_gpu_weights_.empty();
+    acquire_compute_resources();
     return true;
 }
 

--- a/src/s2_pipeline.cpp
+++ b/src/s2_pipeline.cpp
@@ -303,91 +303,6 @@ static void sync_tokenizer_config_from_model(Tokenizer& tokenizer, const SlowARM
 Pipeline::Pipeline() {}
 Pipeline::~Pipeline() {}
 
-static bool read_all_tensor_data(
-    const std::string & gguf_path,
-    gguf_context * gguf_ctx,
-    s2::SlowARModel & model,
-    s2::AudioCodec & codec)
-{
-    const size_t data_offset = gguf_get_data_offset(gguf_ctx);
-    const int64_t n_tensors  = gguf_get_n_tensors(gguf_ctx);
-
-    std::FILE * f = std::fopen(gguf_path.c_str(), "rb");
-    if (!f) {
-        std::cerr << "[Pipeline] Cannot reopen " << gguf_path << " for data loading." << std::endl;
-        return false;
-    }
-
-    const auto & model_weights = model.weight_tensor_set();
-    ggml_context * codec_ctx = codec.weights_ctx();
-    std::vector<uint8_t> tmp;
-
-    for (int64_t ti = 0; ti < n_tensors; ++ti) {
-        const char * tname = gguf_get_tensor_name(gguf_ctx, ti);
-        const size_t toff  = data_offset + gguf_get_tensor_offset(gguf_ctx, ti);
-
-        ggml_tensor * t = ggml_get_tensor(model.weights_ctx(), tname);
-        if (t && model_weights.find(t) != model_weights.end()) {
-            const size_t tsize = ggml_nbytes(t);
-            if (tmp.size() < tsize) tmp.resize(tsize);
-#ifdef _WIN32
-            _fseeki64(f, (int64_t)toff, SEEK_SET);
-#else
-            fseeko(f, (off_t)toff, SEEK_SET);
-#endif
-            if (std::fread(tmp.data(), 1, tsize, f) != tsize) {
-                std::cerr << "[Pipeline] Failed to read tensor: " << tname << std::endl;
-                std::fclose(f);
-                return false;
-            }
-            ggml_backend_tensor_set(t, tmp.data(), 0, tsize);
-            continue;
-        }
-
-        if (codec_ctx) {
-            t = ggml_get_tensor(codec_ctx, tname);
-            if (t) {
-                const size_t tsize = ggml_nbytes(t);
-                if (tmp.size() < tsize) tmp.resize(tsize);
-#ifdef _WIN32
-                _fseeki64(f, (int64_t)toff, SEEK_SET);
-#else
-                fseeko(f, (off_t)toff, SEEK_SET);
-#endif
-                if (std::fread(tmp.data(), 1, tsize, f) != tsize) {
-                    std::cerr << "[Pipeline] Failed to read tensor: " << tname << std::endl;
-                    std::fclose(f);
-                    return false;
-                }
-                ggml_backend_tensor_set(t, tmp.data(), 0, tsize);
-                continue;
-            }
-        }
-
-    }
-    tmp.clear();
-    tmp.shrink_to_fit();
-    std::fclose(f);
-
-    if (!codec.refresh_host_caches()) {
-        std::cerr << "[Pipeline] Failed to refresh codec host caches after weight load." << std::endl;
-        return false;
-    }
-
-#ifdef __linux__
-    {
-        int fd = ::open(gguf_path.c_str(), O_RDONLY);
-        if (fd >= 0) {
-            ::posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
-            ::close(fd);
-        }
-    }
-#endif
-
-    S2_LOG_INFO_STREAM("[Model] Weights loaded. Total tensors: " << n_tensors << std::endl);
-    return true;
-}
-
 bool Pipeline::init(const PipelineParams & params) {
     tokenizer_ref_ = &owned_tokenizer_;
     model_ref_ = &owned_model_;
@@ -477,45 +392,51 @@ bool Pipeline::init(const PipelineParams & params) {
             safe_print_ln("Pipeline: loading codec on " + backend_label +
                           " device " + std::to_string(codec_gpu_device) + "...");
         }
+
         codec_loaded = codec().load_shared(&model(), shared_gguf, params.model_path, codec_gpu_device, codec_backend_type);
+
         if (!codec_loaded) {
             if (codec_backend_type == BackendType::Metal) {
-                safe_print_warn_ln(
-                    "Pipeline warning: codec " + backend_label +
-                    " load failed, falling back to CPU.");
+                safe_print_warn_ln("Pipeline warning: codec " + backend_label + " load failed, falling back to CPU.");
             } else {
-                safe_print_warn_ln(
-                    "Pipeline warning: codec " + backend_label +
-                    " load failed on device " + std::to_string(codec_gpu_device) +
-                    ", falling back to CPU.");
+                safe_print_warn_ln("Pipeline warning: codec " + backend_label + " load failed on device " +
+                                   std::to_string(codec_gpu_device) + ", falling back to CPU.");
             }
         }
     }
+
     if (!codec_loaded) {
         if (!use_gpu_codec) {
             safe_print_ln("Pipeline: loading codec on CPU.");
         }
         codec_loaded = codec().load_shared(&model(), shared_gguf, params.model_path, -1, BackendType::CPU);
     }
+
     if (!codec_loaded) {
         safe_print_error_ln("Pipeline error: could not load codec from " + params.model_path);
         gguf_free(shared_gguf);
         return false;
     }
 
-    if (!read_all_tensor_data(params.model_path, shared_gguf, model(), codec())) {
-        safe_print_error_ln("Pipeline error: failed to read tensor data from " + params.model_path);
-        gguf_free(shared_gguf);
-        return false;
-    }
-
     gguf_free(shared_gguf);
 
+    if (!codec().refresh_host_caches_from_mmap()) {
+        safe_print_error_ln("Pipeline error: failed to refresh VQ caches from mmap");
+        return false;
+    }
     const auto codec_t1 = std::chrono::steady_clock::now();
+
+    const auto model_weights_t0 = std::chrono::steady_clock::now();
+    if (!model().allocate_and_load_weights()) {
+        safe_print_error_ln("Pipeline error: failed to allocate and load Slow-AR weights");
+        return false;
+    }
+    const auto model_weights_t1 = std::chrono::steady_clock::now();
 
     sync_tokenizer_config_from_model(tokenizer(), model());
 
     initialized_ = true;
+
     const auto init_t1 = std::chrono::steady_clock::now();
     safe_print_ln(
         "[Metrics] Init: tokenizer=" +
@@ -524,7 +445,9 @@ bool Pipeline::init(const PipelineParams & params) {
         std::to_string(std::chrono::duration<double, std::milli>(model_t1 - model_t0).count()) +
         " ms, codec=" +
         std::to_string(std::chrono::duration<double, std::milli>(codec_t1 - codec_t0).count()) +
-        " ms (" + codec().backend_name() + "), total=" +
+        " ms (" + codec().backend_name() + "), model_weights=" +
+        std::to_string(std::chrono::duration<double, std::milli>(model_weights_t1 - model_weights_t0).count()) +
+        " ms, total=" +
         std::to_string(std::chrono::duration<double, std::milli>(init_t1 - init_t0).count()) +
         " ms, max_rss=" +
         std::to_string(get_max_rss_mb()) + " MB");

--- a/src/s2_pipeline.cpp
+++ b/src/s2_pipeline.cpp
@@ -301,7 +301,11 @@ static void sync_tokenizer_config_from_model(Tokenizer& tokenizer, const SlowARM
 }
 
 Pipeline::Pipeline() {}
-Pipeline::~Pipeline() {}
+Pipeline::~Pipeline() {
+    if (pending_offload_thread_.joinable()) {
+        pending_offload_thread_.join();
+    }
+}
 
 bool Pipeline::init(const PipelineParams & params) {
     tokenizer_ref_ = &owned_tokenizer_;
@@ -436,6 +440,19 @@ bool Pipeline::init(const PipelineParams & params) {
     sync_tokenizer_config_from_model(tokenizer(), model());
 
     initialized_ = true;
+    
+    model_prefers_gpu_ = model().is_weights_on_gpu();
+    codec_prefers_gpu_ = use_gpu_codec;
+
+    if (model_prefers_gpu_ && codec_prefers_gpu_) {
+        safe_print_ln("[Pipeline] VRAM State Machine: Case 1 (Both prefer GPU) - Codec is lazily allocated on demand.");
+    } else if (model_prefers_gpu_ && !codec_prefers_gpu_) {
+        safe_print_ln("[Pipeline] VRAM State Machine: Case 2 (Slow-AR GPU, Codec CPU) - Ready.");
+    } else if (!model_prefers_gpu_ && codec_prefers_gpu_) {
+        safe_print_ln("[Pipeline] VRAM State Machine: Case 3 (Slow-AR CPU, Codec GPU) - Codec is lazily allocated on demand.");
+    } else {
+        safe_print_ln("[Pipeline] VRAM State Machine: Case 4 (All CPU) - Ready.");
+    }
 
     const auto init_t1 = std::chrono::steady_clock::now();
     safe_print_ln(
@@ -712,9 +729,28 @@ bool Pipeline::synthesize_raw(const PipelineParams & params, AudioData & ref_aud
         return false;
     }
 
+    std::thread pre_restore_thread;
+    bool pre_restore_started = false;
+    
+    if (params.enable_vram_swap && params.is_persistent && 
+        model_prefers_gpu_ && !model().is_weights_on_gpu()) {
+        safe_print_ln("[Pipeline] Hot-Swap: Pre-fetching Slow-AR to VRAM in background...");
+        pre_restore_started = true;
+        pre_restore_thread = std::thread([this]() {
+            model().acquire_compute_resources();
+            model().restore_weights_to_gpu();
+        });
+    }
+
     if (!resolve_reference_prompt_locked(params, ref_audio, ref_codes, T_prompt,
                                          effective_prompt_text, ref_encode_ms)) {
+        if (pre_restore_started) pre_restore_thread.join();
         return false;
+    }
+
+    if (pre_restore_started) {
+        pre_restore_thread.join();
+        safe_print_ln("[Pipeline] Hot-Swap: Background pre-fetch complete.");
     }
 
     PipelineParams effective_params = params;
@@ -756,11 +792,42 @@ bool Pipeline::synthesize_prompt_codes_locked(const PipelineParams & params, con
         return false;
     }
 
+    if (params.enable_vram_swap) {
+        if (pending_offload_thread_.joinable()) {
+            pending_offload_thread_.join();
+        }
+    }
+
     CodecDecodeCacheScope codec_decode_cache_scope(codec());
     model().clear_kv_cache();
 
     safe_print_ln("--- Pipeline Synthesize ---");
     safe_print_ln("Text: " + params.text);
+
+    if (params.enable_vram_swap) {
+        if (model_prefers_gpu_ && !model().is_weights_on_gpu()) {
+            safe_print_ln("[Pipeline] Restoring Slow-AR to VRAM for generation...");
+            model().acquire_compute_resources();
+            model().restore_weights_to_gpu();
+            safe_print_ln("[VRAM Diag] Post-SlowAR restore: Slow-AR=" + std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" + std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+        }
+
+        if (!model_prefers_gpu_ && codec_prefers_gpu_ && !codec().is_weights_on_gpu()) {
+            safe_print_ln("[Pipeline] Pre-loading Audio Codec to VRAM (hiding behind CPU gen)...");
+            codec().restore_weights_to_gpu();
+            safe_print_ln("[VRAM Diag] Post-Codec restore: Slow-AR=" + std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" + std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+        }
+
+        if (model_prefers_gpu_ && codec_prefers_gpu_ && codec().is_weights_on_gpu()) {
+            safe_print_ln("[Pipeline] Freeing Audio Codec from VRAM for Slow-AR generation...");
+            codec().free_gpu_weights();
+            safe_print_ln("[VRAM Diag] Post-Codec free: Slow-AR=" + std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" + std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+        }
+        
+        safe_print_ln("[VRAM Diag] End-Phase1: Slow-AR=" +
+            std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" +
+            std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+    }
 
     const int32_t num_codebooks = model().hparams().num_codebooks;
 
@@ -786,19 +853,72 @@ bool Pipeline::synthesize_prompt_codes_locked(const PipelineParams & params, con
         return false;
     }
 
+    if (params.enable_vram_swap) {
+        if (model_prefers_gpu_ && model().is_weights_on_gpu()) {
+            if (params.is_persistent) {
+                if (codec_prefers_gpu_) {
+                    safe_print_ln("[Pipeline] Freeing Slow-AR from VRAM to make room for GPU Audio Codec...");
+                    model().free_gpu_weights();
+                    model().clear_kv_cache();
+                    safe_print_ln("[VRAM Diag] Post-SlowAR free: Slow-AR=" + std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" + std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+                }
+            } else {
+                safe_print_ln("[Pipeline] Single-shot: Freeing Slow-AR from VRAM...");
+                model().free_gpu_weights();
+                model().free_compute_buffers(); 
+                safe_print_ln("[VRAM Diag] Post-SlowAR free: Slow-AR=" + std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" + std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+            }
+        }
+        
+        if (codec_prefers_gpu_ && !codec().is_weights_on_gpu()) {
+            safe_print_ln("[Pipeline] Restoring Audio Codec to VRAM for decode...");
+            codec().restore_weights_to_gpu();
+            safe_print_ln("[VRAM Diag] Post-Codec restore: Slow-AR=" + std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" + std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+        }
+    }
+
     const int32_t offline_decode_stride_frames =
         params.stream_decode_stride_frames > 0 ? params.stream_decode_stride_frames : 16;
     double decode_ms = 0.0;
     int32_t decode_batches = 0;
     const auto decode_t0 = std::chrono::steady_clock::now();
-    if (!decode_codes_windowed(codec(), res.codes.data(), res.n_frames, num_codebooks,
+
+    bool decode_ok = decode_codes_windowed(codec(), res.codes.data(), res.n_frames, num_codebooks,
                                params.gen.n_threads, offline_decode_stride_frames,
                                params.codec_decode_context_frames,
-                               audio_out, &decode_ms, &decode_batches)) {
+                               audio_out, &decode_ms, &decode_batches);
+       
+    const auto decode_t1 = std::chrono::steady_clock::now();
+
+    if (params.enable_vram_swap) {
+        if (params.is_persistent) {
+            if (params.enable_hot_swap) {
+                safe_print_ln("[Pipeline] Hot-Swap: Releasing compute resources...");
+                model().free_compute_buffers();
+                
+                safe_print_ln("[Pipeline] Hot-Swap: Spawning background thread to free VRAM & RAM...");
+                std::thread offload_thread([this]() {
+                    if (model().is_weights_on_gpu()) model().free_gpu_weights();
+                    if (codec().is_weights_on_gpu()) codec().free_gpu_weights();
+                    
+                    model().mapped_file().drop_page_cache();
+                    codec().mapped_file().drop_page_cache();
+                    
+                    safe_print_ln("[Pipeline] Hot-Swap: Background VRAM & RAM free complete.");
+                });
+                pending_offload_thread_ = std::move(offload_thread);
+            } else {
+                if (codec().is_weights_on_gpu()) codec().free_gpu_weights();
+            }
+        } else {
+            safe_print_ln("[Pipeline] Single-shot mode: Skipping post-decode VRAM restore.");
+        }
+    }
+
+    if (!decode_ok) {
         safe_print_error_ln("Pipeline error: decode failed.");
         return false;
     }
-    const auto decode_t1 = std::chrono::steady_clock::now();
 
     model().clear_kv_cache();
     const auto synth_t1 = std::chrono::steady_clock::now();
@@ -831,6 +951,13 @@ bool Pipeline::synthesize_prompt_codes_locked(const PipelineParams & params, con
         " ms/frame, gen_rtf=" + std::to_string(gen_rtf) +
         ", total_rtf=" + std::to_string(total_rtf) +
         ", max_rss=" + std::to_string(get_max_rss_mb()) + " MB");
+
+    if (params.enable_vram_swap) {
+        safe_print_ln("[VRAM Diag] Post-Phase3: Slow-AR=" + 
+            std::to_string(model().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB, Codec=" +
+            std::to_string(codec().get_gpu_memory_usage_bytes() / 1024 / 1024) + " MB");
+    }
+
     return true;
 }
 
@@ -848,10 +975,29 @@ bool Pipeline::synthesize_streaming_raw(const PipelineParams & params, AudioData
         return false;
     }
 
+    std::thread pre_restore_thread;
+    bool pre_restore_started = false;
+    
+    if (params.enable_vram_swap && params.is_persistent && 
+        model_prefers_gpu_ && !model().is_weights_on_gpu()) {
+        safe_print_ln("[Pipeline] Hot-Swap: Pre-fetching Slow-AR to VRAM in background...");
+        pre_restore_started = true;
+        pre_restore_thread = std::thread([this]() {
+            model().acquire_compute_resources();
+            model().restore_weights_to_gpu();
+        });
+    }
+
     if (!resolve_reference_prompt_locked(params, ref_audio, ref_codes, T_prompt,
                                          effective_prompt_text, ref_encode_ms)) {
+        if (pre_restore_started) pre_restore_thread.join();
         sink.on_error("Failed to resolve reference prompt");
         return false;
+    }
+
+    if (pre_restore_started) {
+        pre_restore_thread.join();
+        safe_print_ln("[Pipeline] Hot-Swap: Background pre-fetch complete.");
     }
 
     PipelineParams effective_params = params;
@@ -884,6 +1030,22 @@ bool Pipeline::synthesize_streaming_prompt_codes_locked(const PipelineParams & p
         safe_print_error_ln("Pipeline not initialized.");
         sink.on_error("Pipeline not initialized");
         return false;
+    }
+
+    if (params.enable_vram_swap) {
+        if (pending_offload_thread_.joinable()) {
+            pending_offload_thread_.join();
+        }
+        
+        if (model_prefers_gpu_ && !model().is_weights_on_gpu()) {
+            safe_print_ln("[Pipeline] Streaming: Restoring Slow-AR to VRAM...");
+            model().acquire_compute_resources();
+            model().restore_weights_to_gpu();
+        }
+        if (codec_prefers_gpu_ && !codec().is_weights_on_gpu()) {
+            safe_print_ln("[Pipeline] Streaming: Restoring Audio Codec to VRAM...");
+            codec().restore_weights_to_gpu();
+        }
     }
 
     CodecDecodeCacheScope codec_decode_cache_scope(codec());
@@ -1099,6 +1261,31 @@ bool Pipeline::synthesize_streaming_prompt_codes_locked(const PipelineParams & p
         " ms/frame, ar_avg=" + std::to_string(ar_ms_per_frame) +
         " ms/frame, total_rtf=" + std::to_string(total_rtf) +
         ", max_rss=" + std::to_string(get_max_rss_mb()) + " MB");
+
+    if (params.enable_vram_swap) {
+        if (params.is_persistent) {
+            if (params.enable_hot_swap) {
+                safe_print_ln("[Pipeline] Hot-Swap: Releasing compute resources...");
+                model().free_compute_buffers();
+                
+                safe_print_ln("[Pipeline] Hot-Swap: Spawning background thread to free VRAM & RAM...");
+                std::thread offload_thread([this]() {
+                    if (model().is_weights_on_gpu()) model().free_gpu_weights();
+                    if (codec().is_weights_on_gpu()) codec().free_gpu_weights();
+                    
+                    model().mapped_file().drop_page_cache();
+                    codec().mapped_file().drop_page_cache();
+                    
+                    safe_print_ln("[Pipeline] Hot-Swap: Background VRAM & RAM free complete.");
+                });
+                pending_offload_thread_ = std::move(offload_thread);
+            } else {
+                if (codec().is_weights_on_gpu()) codec().free_gpu_weights();
+            }
+        } else {
+            safe_print_ln("[Pipeline] Single-shot mode: Skipping post-stream VRAM restore.");
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
### What this solves
In the final stages when it's time to process Audio Codec,  Slow-AR isn't evicted from VRAM despite being no longer needed. So our VRAM footprint becomes `Slow-AR + compute buffers + Audio Codec + compute buffers + KV caches` peaking at `6-7 GB on q8_0` with transient spikes during buffer allocations (possibly due to fragmentaton?). In effect this causes high memory pressure and leads to OOMs if you were nearing hardware limit already.

To solve this we selectively load the submodels and evict them from VRAM once they finish. By doing this we achieve 2.2 GB VRAM usage during Audio Codec phase of processing, and we also only load the Audio Codec when it's needed so the initial VRAM load is also lowered by ~1 GB.

With memory-mapped page cache sitting in RAM we can near-instantly fetch them when needed, and we hide the latency of this (mostly PCIe) fetch by scheduling it in background thread as we finish other sequential processes.

We've two atomic commits for easier review:
1. The first commit ad61fbbf419e4b4cf06cbe45672be2873b9b5d47 replaces the old fread and read all tensors approach with mmaped lazy allocation APIs. It should be more efficient than fread, otherwise not much change in practice. It's the groundwork for the next commit.
2. The second commit c6680adcd14bf5b49c1ee6574cbb8b95603f3784 adds the vram-swap state machine (opt out) and "hot-swap" (opt in) parameters. 
The new default behavior after the second commit can be categorized by opt-in and opt-out:

### Opt out vram-swap
Unless you opt out, we evict already-processed submodels from VRAM, and lazily loads them as needed. Because we're using mmap these loads are near-instant since we fetch them from RAM instead of disk. We also keep compute buffers in VRAM as they're relatively small but take longer to re-initiate (~170 MB in vulkan). Your OS might (partially) reclaim the RAM page cache incurring some disk IO for the reclaimed pages, but it's generally as fast as keeping the models loaded in VRAM all the time. This depends on page faults. It's also more efficient than fread (double copy) since we don't load all tensors at once and use zero-copy DMA. 
`--no-vram-swap`

### Opt in hot-swap
With the opt-in hot-swap behavior, we free anything from not only VRAM but also RAM. This includes compute buffers and the mmap page cache, landing us at a 100 MB RAM + 25 MB VRAM footprint. This is the "I don't trust my drivers & OS to free memory in a timely fashion and want to evict them aggressively, I need my VRAM back immediately for other tasks" option. This also ensures you'll need to read from disk each request, so I advise only using this if you absolutely need lowest memory footprint or the model is in m.2 SSD. It's a rather "dumb" solution compared to vram-swap. I advise against using this unless you know what you're doing as this can take 4x longer to process compared to vram-swap only. You're in effect doing cold boots every request and purely limited by your IO speed (mines a slow 200 MB/s SATA SSD)
`--hot-swap`

## Key Features

### 1. Zero-Copy `mmap` Architecture
- Cross-platform `MappedFile` RAII wrapper (POSIX `mmap` / Windows `CreateFileMapping`).
- Weights are DMAd directly from the OS page cache to VRAM, bypassing RAM buffers.
- Boot times are reduced by eliminating the CPU-bound disk read phase and lazy loading mechanism.

### 2. Lazy Weight Allocation
- The Audio Codec now sits at **0 MB VRAM** at startup. It is only allocated on-demand the first time `encode()` or `decode()` is called via `ensure_weights_loaded()`.
- VQ codebook caches are populated directly from the `mmap` pointer into system RAM.

### 3. Phase-Gated VRAM Swapping
- During inference, the pipeline actively swaps sub-models. Slow-AR weights and the KV cache are explicitly freed *before* the Audio Codec is loaded into VRAM for the decode phase.
- Eliminates VRAM overlap, allowing the full pipeline to run with lower VRAM footprint allowing you turn higher quants or use your GPU for other tasks without hogging memory.
- We call `ggml_backend_synchronize` to nudge drivers to free VRAM instead of deferring & thrashing.

### 4. Hot-Swap Mode (`--hot-swap`)
- Adds an aggressive memory reclamation mode for desktop/gaming environments.
- After a request completes, background threads free VRAM and explicitly call `madvise(MADV_DONTNEED)` / `posix_fadvise(DONTNEED)` to evict the 5.3 GB GGUF file from the OS page cache.
- Drops idle footprint to **~100 MB RAM / ~25 MB VRAM**, ensuring zero interference with other applications (like games).

## Practical usage/footprint

| Mode | Idle RAM | Idle VRAM | Next Request Latency | Recommended use |
| :--- | :--- | :--- | :--- | :--- |
| **Default (VRAM Swap)** | ~5 GB (page cache) | ~168 MB (schedulers) | ~1.5s, sometimes disk IO | Dedicated servers, high-RAM desktops |
| **`--hot-swap`** | ~100 MB | ~25 MB | Cold boot slow (IO bottleneck) | Desktop gaming, memory-constrained PCs |
| **`--no-vram-swap`** | ~5 GB | Full model + codec | Instant | Single-shot CLI |

## Some metrics
**Read me!**:
- The first half (5) configurations are on upstream or slightly newer while the last 6 are up-to-date with my [main repo](https://github.com/Skyrion9/s2.cpp) which has various other optimizations that can exaggerate the gap (all PRs here merged). If you want a comparison as to "does vram-swap or hot-swap reduce performance" compare them with **Baseline R(equest)1 and R2** which has `--no-vram-swap` flag.
- This graph is of only "Hello world, how are you today?" short generation. While GPU SlowAR + CPU Codec might seem like it's winning, it actually flops really bad when it has to generate anything longer. The gaps between each result grows exponentially as generations take longer.
- Notice the hot-swap R2 being much slower in "total speed" metrics. This is because we killed the RAM cache after R1 was through and my SSD is only 200 MB/s. Generation speed itself stays identical, just IO bottleneck.

<img width="1600" height="853" alt="s3_real_time_factors" src="https://github.com/user-attachments/assets/90c99fc1-e38a-4128-847f-0642c9edb23f" />

<img width="1600" height="853" alt="s3_throughput_per_frame" src="https://github.com/user-attachments/assets/6a553364-f4c8-4e1a-85ed-10f8a27946c0" />

<img width="1600" height="853" alt="s3_execution_latencies" src="https://github.com/user-attachments/assets/1bdd36b2-f869-4122-9ac5-b96c46d47896" />

<img width="1024" height="559" alt="Untitled" src="https://github.com/user-attachments/assets/8ab09017-13d5-4b95-bf14-f2338b62741e" />

<img width="1600" height="720" alt="5_vram_lifecycle_updated_exact" src="https://github.com/user-attachments/assets/a54d12bd-f827-4bd0-b580-0385fc8b21f0" />


### Notes
- You might see VRAM or RAM not evicted instantly. This can be due to your OS, drivers, backend what have you deciding to defer the operation, usually due to power saving optimizations such as lazy RCU in Linux.
- Your task manager will report 5.3 GB~ RAM usage (on linux htop would show it as cache). This is not the same as say, a game using 5.3 GB RAM, because this is a memory mapping to your GGUF file it can be readily freed by OS without issue. Say, you've 16 GB RAM and opened a 12 GB game with s2.cpp running. OS will reclaim memory from s2 and when handling the next request s2 will simply read from whatever is left in memory and fetch what's missing from disk. It's highly efficient, but if your OS disagrees with it you can just use hot-swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lazy, mapped-file loading for model and codec weights.
  * Added GPU weight controls, residency status, and memory usage reporting.
  * Added optional CPU placement for decoder and codebook components.
  * Added VRAM swapping, background hot-swapping, and persistent server mode.
  * Added CLI options for disabling VRAM swapping and enabling hot-swapping.

* **Performance**
  * Reduced startup and idle GPU memory usage through on-demand loading.
  * Improved cache refresh and synthesis resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->