### PR TITLE
perf: replace standard attention with unified flash attention

### DIFF
--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -743,8 +743,9 @@ bool SlowARModel::init_kv_cache(int32_t max_seq_len) {
         return false;
     }
 
-    memory_k_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, n_head_kv, max_seq_len, n_layer);
-    memory_v_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, n_head_kv, max_seq_len, n_layer);
+    // Layout for flash attention
+    memory_k_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, max_seq_len, n_head_kv, n_layer);
+    memory_v_ = ggml_new_tensor_4d(ctx_kv_, GGML_TYPE_F16, head_dim, max_seq_len, n_head_kv, n_layer);
 
     ggml_backend_t kv_backend = (n_gpu_layers_ > 0 && backend_gpu_) ? backend_gpu_ : backend_cpu_;
     kv_buf_ = ggml_backend_alloc_ctx_tensors(ctx_kv_, kv_backend);
@@ -961,6 +962,24 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
         x = ggml_mul(ctx0, x, ggml_repeat(ctx0, token_scale, x));
     }
 
+    ggml_tensor * fa_mask = nullptr;
+    std::vector<ggml_fp16_t> mask_data;
+
+    if (n_tokens > 1) {
+        int64_t kv_len = n_past_ + n_tokens;
+        fa_mask = ggml_new_tensor_4d(ctx0, GGML_TYPE_F16, kv_len, n_tokens, 1, 1);
+        mask_data.resize(kv_len * n_tokens);
+        for (int j = 0; j < n_tokens; ++j) {
+            for (int i = 0; i < kv_len; ++i) {
+                if (i > n_past_ + j) {
+                    mask_data[j * kv_len + i] = ggml_fp32_to_fp16(-INFINITY);
+                } else {
+                    mask_data[j * kv_len + i] = ggml_fp32_to_fp16(0.0f);
+                }
+            }
+        }
+    }
+
     for (int32_t il = 0; il < hparams_.block_count; ++il) {
         const auto & layer = weights_.layers[il];
 
@@ -990,53 +1009,44 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
 
         const size_t layer_off_k = static_cast<size_t>(il) * memory_k_->nb[3];
         const size_t layer_off_v = static_cast<size_t>(il) * memory_v_->nb[3];
-        const size_t token_off_k = static_cast<size_t>(n_past_) * memory_k_->nb[2];
-        const size_t token_off_v = static_cast<size_t>(n_past_) * memory_v_->nb[2];
+        const size_t token_off_k = static_cast<size_t>(n_past_) * memory_k_->nb[1];
+        const size_t token_off_v = static_cast<size_t>(n_past_) * memory_v_->nb[1];
 
         ggml_tensor * k_slot = ggml_view_3d(ctx0, memory_k_,
-            head_dim, n_head_kv, n_tokens,
+            head_dim, n_tokens, n_head_kv,
             memory_k_->nb[1], memory_k_->nb[2],
             layer_off_k + token_off_k);
         ggml_tensor * v_slot = ggml_view_3d(ctx0, memory_v_,
-            head_dim, n_head_kv, n_tokens,
+            head_dim, n_tokens, n_head_kv,
             memory_v_->nb[1], memory_v_->nb[2],
             layer_off_v + token_off_v);
-        ggml_build_forward_expand(gf, ggml_cpy(ctx0, k, k_slot));
-        ggml_build_forward_expand(gf, ggml_cpy(ctx0, v, v_slot));
+            
+        // Permute k and v to match the cache layout
+        ggml_tensor * k_perm = ggml_cont(ctx0, ggml_permute(ctx0, k, 0, 2, 1, 3));
+        ggml_tensor * v_perm = ggml_cont(ctx0, ggml_permute(ctx0, v, 0, 2, 1, 3));
 
-        ggml_tensor * k_mem = k;
-        ggml_tensor * v_mem = v;
-        if (n_past_ > 0) {
-            ggml_tensor * k_past = ggml_reshape_3d(ctx0,
-                ggml_view_1d(ctx0, memory_k_, static_cast<int64_t>(n_past_) * kv_size, layer_off_k),
-                head_dim, n_head_kv, n_past_);
-            ggml_tensor * v_past = ggml_reshape_3d(ctx0,
-                ggml_view_1d(ctx0, memory_v_, static_cast<int64_t>(n_past_) * kv_size, layer_off_v),
-                head_dim, n_head_kv, n_past_);
-            if (k_past->type != k->type) k_past = ggml_cast(ctx0, k_past, k->type);
-            if (v_past->type != v->type) v_past = ggml_cast(ctx0, v_past, v->type);
-            k_mem = ggml_concat(ctx0, k_past, k, 2);
-            v_mem = ggml_concat(ctx0, v_past, v, 2);
-        }
+        ggml_build_forward_expand(gf, ggml_cpy(ctx0, k_perm, k_slot));
+        ggml_build_forward_expand(gf, ggml_cpy(ctx0, v_perm, v_slot));
 
-        if (n_head != n_head_kv && q->type != GGML_TYPE_F32) {
-            q = ggml_cast(ctx0, q, GGML_TYPE_F32);
-        }
-        ggml_tensor * k_rep = repeat_interleave_heads(ctx0, k_mem, n_head / n_head_kv);
-        ggml_tensor * v_rep = repeat_interleave_heads(ctx0, v_mem, n_head / n_head_kv);
+        // Permute Q to [head_dim, n_tokens, n_head, 1] for flash_attn_ext
+        ggml_tensor * Q_fa = ggml_permute(ctx0, q, 0, 2, 1, 3);
 
-        ggml_tensor * Q   = ggml_permute(ctx0, q,     0, 2, 1, 3);
-        ggml_tensor * K   = ggml_permute(ctx0, k_rep, 0, 2, 1, 3);
-        ggml_tensor * KQ  = mul_mat_checked(ctx0, K, Q, "mul_mat:kq");
-        ggml_tensor * KQs = ggml_scale(ctx0, KQ, attn_scale);
-        ggml_tensor * KQm = ggml_diag_mask_inf(ctx0, KQs, n_past_);
-        ggml_tensor * KQf = ggml_soft_max(ctx0, KQm);
+        int64_t kv_len = n_past_ + n_tokens;
+        ggml_tensor * k_cache = ggml_view_3d(ctx0, memory_k_,
+            head_dim, kv_len, n_head_kv,
+            memory_k_->nb[1], memory_k_->nb[2], layer_off_k);
 
-        ggml_tensor * V       = ggml_cont(ctx0, ggml_permute(ctx0, v_rep, 1, 2, 0, 3));
-        ggml_tensor * KQV     = mul_mat_checked(ctx0, V, KQf, "mul_mat:kqv");
-        ggml_tensor * KQVm    = ggml_permute(ctx0, KQV, 0, 2, 1, 3);
-        ggml_tensor * attn_cur = ggml_cpy(ctx0, KQVm,
-                                          ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
+        ggml_tensor * v_cache = ggml_view_3d(ctx0, memory_v_,
+            head_dim, kv_len, n_head_kv,
+            memory_v_->nb[1], memory_v_->nb[2], layer_off_v);
+
+        ggml_tensor * attn_fa = ggml_flash_attn_ext(
+            ctx0, Q_fa, k_cache, v_cache, fa_mask, attn_scale, 0.0f, 0.0f);
+        
+        // Output is [head_dim, n_head, n_tokens, 1], flatten to [q_size, n_tokens] for wo
+        ggml_tensor * attn_cur = ggml_cpy(ctx0, attn_fa,
+             ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
+
         ggml_tensor * attn_out = mul_mat_checked(ctx0, layer.wo, attn_cur, "mul_mat:wo");
 
         ggml_tensor * h     = ggml_add(ctx0, x, attn_out);
@@ -1076,6 +1086,10 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
     }
     for (int32_t cb = 0; cb < hparams_.num_codebooks; ++cb) {
         ggml_backend_tensor_set(cb_id_tensors[cb], cb_vals[cb].data(), 0, n_tokens * sizeof(int32_t));
+    }
+    
+    if (fa_mask) {
+        ggml_backend_tensor_set(fa_mask, mask_data.data(), 0, mask_data.size() * sizeof(ggml_fp16_t));
     }
 
     if (ggml_backend_sched_graph_compute(sched_, gf) != GGML_STATUS_SUCCESS) {

--- a/src/s2_model.cpp
+++ b/src/s2_model.cpp
@@ -1043,9 +1043,8 @@ bool SlowARModel::eval_cached(const std::vector<int32_t> & flat_tokens,
         ggml_tensor * attn_fa = ggml_flash_attn_ext(
             ctx0, Q_fa, k_cache, v_cache, fa_mask, attn_scale, 0.0f, 0.0f);
         
-        // Output is [head_dim, n_head, n_tokens, 1], flatten to [q_size, n_tokens] for wo
-        ggml_tensor * attn_cur = ggml_cpy(ctx0, attn_fa,
-             ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, q_size, n_tokens));
+        // Reshape [head_dim, n_head, n_tokens, 1] → [q_size, n_tokens] (zero-copy view)
+        ggml_tensor * attn_cur = ggml_reshape_2d(ctx0, attn_fa, q_size, n_tokens);
 
         ggml_tensor * attn_out = mul_mat_checked(ctx0, layer.wo, attn_cur, "mul_mat:wo");
 


### PR DESCRIPTION
Replaces the standard (naive) attention implementation in `SlowARModel::eval_cached` with a single unified `ggml_flash_attn_ext` call for all token counts.

The previous attention path used a multi-step standard attention pipeline:

1. Concatenate past KV cache with current K/V
2. `repeat_interleave_heads` to expand KV heads for GQA
3. `mul_mat` to compute QK scores
4. `ggml_scale` + `ggml_diag_mask_inf` + `ggml_soft_max`
5. `mul_mat` to compute KQV output

This required **8+ separate GPU shader dispatches per layer** and materialized the full $N \times N$ attention matrix in VRAM, creating an $O(N^2)$ memory bandwidth bottleneck.

**Changes:**

**KV cache layout** (`init_kv_cache`):
- Dimensions 1 and 2 are swapped from `[head_dim, n_head_kv, max_seq_len, n_layer]` to `[head_dim, max_seq_len, n_head_kv, n_layer]`, placing the sequence dimension at `ne[1]` to match the view shape expected by `ggml_flash_attn_ext`.
- Token offset calculation updated from `nb[2]` to `nb[1]` accordingly.
- K/V write path now includes a `ggml_permute` + `ggml_cont` to transpose from the QKV projection output shape to the cache layout.

**Causal mask generation** (`eval_cached`):
- For `n_tokens > 1`: an F16 causal mask of shape `[kv_len, n_tokens, 1, 1]` is built on the CPU and uploaded to the backend before graph compute. Entry `[j][i]` is `-INFINITY` if `i > n_past_ + j`, `0.0f` otherwise.
- For `n_tokens == 1`: `fa_mask` remains `nullptr`. This is not a separate code path — the same `ggml_flash_attn_ext` call executes regardless of token count.

**Attention computation** (`eval_cached`):
- The entire standard attention block (concat, repeat_interleave, KQ mul_mat, scale, diag_mask_inf, soft_max, KQV mul_mat) is replaced with a single `ggml_flash_attn_ext` call.
- Q is permuted to `[head_dim, n_tokens, n_head, 1]`; K/V cache views are `[head_dim, kv_len, n_head_kv]`.
- Output is flattened to `[q_size, n_tokens]` for the `wo` projection.

As a "sideffect" #38 is no longer needed for Linux Radv (Vulkan) on RDNA2 - RX 6700 to function without segfaulting when using prefill_fast, likely due to ggml_soft_max limitations on ggml vulkan backend for this particular setup.

**Impact:**

| Metric | Before | After |
| :--- | :--- | :--- |
| Shader dispatches per layer (attention) | ~8–10 | ~3 |
| Attention matrix materialized in VRAM | Yes ($O(N^2)$) | No (tiled internally) |

**Benchmarks:**
Can be compared as the improvement over #44 as those graphs implemented the deprecated implementation of FA #40 which wasn't uniform in its approach. You can see that we're running ~20% faster across Total RTF if you compare the R1/R2 results. As before, the non-R1/R2 runs are upstream using prefill instead of prefill_fast as fast_prefill was unusable on my system before this PR.

<img width="1600" height="853" alt="updated_real_time_factors" src="https://github.com/user-attachments/assets/d2ce41f4-fe28-4217-a38f-d57893e48458" />

<img width="1600" height="853" alt="updated_execution_latencies" src="https://github.com/user-attachments/assets/671a5bb5-e565-4aa3-b132-ab34e241b2d9" />

<img width="1600" height="853" alt="updated_throughput_per_frame" src="https://github.com/user-attachments/assets/6ae2d382-f83a-4320-b1ba-063d3d093d53" />

<img width="1024" height="559" alt="Untitled" src="https://github.com/user-attachments/assets/08b41b5b-4f34-4b46-b945-a00646ee03d7" />

<img width="1600" height="720" alt="5_vram_lifecycle_updated_exact" src="https://github.com/user-attachments/assets/12752e38-7790-48c5-84cc-fcd39c74abe2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved processing efficiency for evaluations involving multiple tokens.
  * Optimized attention data handling to support faster, more streamlined inference.
* **Compatibility**
  * Preserved existing attention behavior and downstream results.
  * Continued support for causal attention when processing sequences incrementally or in batches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->